### PR TITLE
buffersize option was being ignored

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -76,7 +76,7 @@ function SerialPort(path, options) {
   if (this.fd == -1) {
     throw new Error("Could not open serial port");
   } else {
-    this.readStream = fs.createReadStream(this.port);
+    this.readStream = fs.createReadStream(this.port,{bufferSize:options.buffersize});
     var dataCallback = (function (me) {
       return (function (buffer) {
         options.parser(me, buffer)


### PR DESCRIPTION
the buffersize option was not being passed to createReadStream which basically meant it was ignored.  This was causing my firmata library to fail because it is using a buffersize of 1.  I added the buffersize option to createReadStream and tested firmata and everything appears to be working.
