### PR TITLE
The "sys" module is now called "util".

### DIFF
--- a/tests/test_read.js
+++ b/tests/test_read.js
@@ -1,15 +1,15 @@
 // Test with the epic VirtualSerialPortApp - http://code.google.com/p/macosxvirtualserialport/
 
 var SerialPort = require("../serialport").SerialPort;
-var sys = require("sys"), repl = require("repl");
+var util = require("util"), repl = require("repl");
 
 var serial_port = new SerialPort("/dev/master", {baudrate: 9600});
 
 serial_port.on("data", function (data) {
-  sys.puts("here: "+data);
+  util.puts("here: "+data);
 })
 serial_port.on("error", function (msg) {
-  sys.puts("error: "+msg);
+  util.puts("error: "+msg);
 })
 repl.start("=>")
 

--- a/tests/test_write.js
+++ b/tests/test_write.js
@@ -1,7 +1,6 @@
 // Test with the epic VirtualSerialPortApp - http://code.google.com/p/macosxvirtualserialport/
 
 var SerialPort = require("../serialport").SerialPort;
-var sys = require("sys");
 
 var serial_port = new SerialPort("/dev/master", {baudrate: 9600});
 


### PR DESCRIPTION
module name "sys" was modified in recent versions of Node.
This is harmless but it should be changed to suppress the warning message.
