### PR TITLE
New "close" listener when device being disconnected

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -86,9 +86,21 @@ function SerialPort(path, options) {
       return (function (err) {
         me.emit("error", err);
       });
-    });
+    })(this);
+    var closeCallback = (function (me) {
+      return (function () {
+        me.emit("close");
+      });
+    })(this);
+    var endCallback = (function (me) {
+      return (function () {
+        me.emit("end");
+      });
+    })(this);
     this.readStream.on("data", dataCallback);
     this.readStream.on("error", errorCallback);
+    this.readStream.on("close", closeCallback);
+    this.readStream.on("end", endCallback);
   }
 }
 


### PR DESCRIPTION
When a serial device is disconnected (e.g. /dev/ttyUSB0), there is no error/event thrown.

This patch adds 2 new listeners: end, close. 
It also fix an issue with the error callback... the callback was not working.

Question: is the "end" listener useful?
