### PR TITLE
For development purpose, changed the node engine version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
-{   "name" : "serialport",
+{
+    "name" : "serialport",
     "version" : "0.7.3",
     "description" : "Welcome your robotic javascript overlords. Better yet, program them!",
     "author": "Chris Williams <voodootikigod@gmail.com>",
@@ -13,5 +14,7 @@
     "dependencies": {
         "bindings": "*"
     },
-    "engines": { "node": "0.6" }
+    "engines": {
+        "node": ">=0.6"
+    }
 }


### PR DESCRIPTION
Currently, node-serialport cannot be used with node 0.7.x because of the restriction in the package.json file. I simply fixed that. It would be great also to push this 0.7.3 version in NPM.
