### PR TITLE
package: remove "install" phase 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
         "type": "git",
         "url": "git://github.com/voodootikigod/node-serialport.git"
     },
-    "scripts": {
-        "install": "node-waf configure build"
-    },
     "dependencies": {
         "bindings": "*"
     },


### PR DESCRIPTION
This enables the node-gyp build. Fixes #51.
