### PR TITLE
Serialport2

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -44,7 +44,7 @@ var _options = {
   baudrate: 9600,
   databits: 8,
   stopbits: 1,
-  parity: 0,
+  parity: 'none',
   flowcontrol: false,
   buffersize: 255,
   parser: parsers.raw


### PR DESCRIPTION
The default of 0 is not correct I think it should be 'none'.  I got an error when the default was 0.  I think changing the parity to be strings instead of numbers might break other projects
