### PR TITLE
fixing bugs

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -74,14 +74,14 @@ function SerialPort(path, options) {
   var self = this;
   process.nextTick(function () {
     options = options || {};
-    options.baudRate = options.baudRate || 9600;
-    options.dataBits = options.dataBits || 8;
+    options.baudRate = options.baudRate || options.baudrate || 9600;
+    options.dataBits = options.dataBits || options.databits || 8;
     options.parity = options.parity || 'none';
-    options.stopBits = options.stopBits || 1;
+    options.stopBits = options.stopBits || options.stopbits || 1;
+    options.bufferSize = options.bufferSize || options.buffersize || 100;
     if (!('flowControl' in options)) {
       options.flowControl = false;
     }
-    options.bufferSize = options.bufferSize || 100;
     options.dataCallback = function (data) {
       options.parser(self, data);
     };
@@ -95,8 +95,11 @@ function SerialPort(path, options) {
 
     if (process.platform == 'win32') {
       path = '\\\\.\\' + path;
-    } else {
-      self.readStream = fs.createReadStream(path, { bufferSize: options.bufferSize });
+    }
+
+    SerialPortBinding.open(path, options, function (err, fd) {
+      self.fd = fd;
+      self.readStream = fs.createReadStream(path, { bufferSize: options.bufferSize, fd: fd });
       self.readStream.on("data", options.dataCallback);
       self.readStream.on("error", options.errorCallback);
       self.readStream.on("close", function () {
@@ -105,10 +108,6 @@ function SerialPort(path, options) {
       self.readStream.on("end", function () {
         self.emit('end');
       });
-    }
-
-    SerialPortBinding.open(path, options, function (err, fd) {
-      self.fd = fd;
       if (err) {
         return self.emit('error', err);
       }


### PR DESCRIPTION
This fixed the bugs that I was having with firmata, everything seems to be working fine now.
1.  Made it so both lower cased and camel cased options work.
2.  Moved the createReadStream inside of the SerialPortBinding.open and passed in the fd returned from .open into the createReadStream.

I have no idea how this affects the windows version but it fixed firmata on mac.
