### PR TITLE
Adding node-gyp as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "bindings": "0.3.0",
     "async": "0.1.18",
     "sf": "0.1.3",
-    "optimist": "~0.3.4"
+    "optimist": "~0.3.4",
+    "node-gyp": "0.6.2"
   },
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
When installing node-serialport without node-gyp globally installed, the actual build does not happen and so the "build" folder doesn't get created. This doesn't trigger an error, but does result in node-serialport not actually working as expected. Adding the node-gyp dependency solves this issue.
