### PR TITLE
Proposed change to serialport ctor to add callback after open or fatal error

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -49,7 +49,13 @@ var _options = {
   buffersize: 255,
   parser: parsers.raw
 };
-function SerialPort (path, options) {
+function SerialPort (path, options, callback) {
+  
+  if (!callback && typeof options == "function") {
+    callback = options; // callback is in the second parameter
+    options = {};
+  }
+  
   options = options || {};
   options.__proto__ = _options;
 
@@ -95,7 +101,9 @@ function SerialPort (path, options) {
       if (self.closing) {
         return;
       }
-      self.emit('error', new Error("Disconnected"));
+      var error = new Error("Disconnected");
+      self.emit('error', error);
+      callback(error);
       self.close();
     };
 
@@ -121,6 +129,7 @@ function SerialPort (path, options) {
       }
 
       self.emit('open');
+      callback();
     });
   });
 }


### PR DESCRIPTION
Change to the ctor api to add a 'completion callback'.  This API change is backwards compatible with existing code.

This change optimizes the common case of waiting to start writing or reading from the SerialPort stream until it is open.  It replaces the code:

var sp = new SerialPort(...);
sp.once('open', function() { doSomethingSerially... } );

with the more concise and understandable form:

var sp = new SerialPort(..., function() { doSomethingSerially... }_;
