### PR TITLE
Firmata issues on windows

### DIFF
--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -31,6 +31,7 @@ v8::Handle<v8::Value> Open(const v8::Arguments& args) {
   strcpy(baton->path, *path);
   baton->baudRate = options->Get(v8::String::New("baudRate"))->ToInt32()->Int32Value();
   baton->dataBits = options->Get(v8::String::New("dataBits"))->ToInt32()->Int32Value();
+  baton->bufferSize = options->Get(v8::String::New("bufferSize"))->ToInt32()->Int32Value();
   baton->parity = ToParityEnum(options->Get(v8::String::New("parity"))->ToString());
   baton->stopBits = ToStopBitEnum(options->Get(v8::String::New("stopBits"))->ToNumber()->NumberValue());
   baton->flowControl = options->Get(v8::String::New("flowControl"))->ToBoolean()->BooleanValue();

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -55,6 +55,7 @@ public:
   int result;
   int baudRate;
   int dataBits;
+  int bufferSize;
   bool flowControl;
   SerialPortParity parity;
   SerialPortStopBits stopBits;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -6,7 +6,7 @@
 #ifdef WIN32
 
 std::list<int> g_closingHandles;
-
+int bufferSize;
 void ErrorCodeToString(const char* prefix, int errorCode, char *errorStr) {
   switch(errorCode) {
   case ERROR_FILE_NOT_FOUND:
@@ -45,6 +45,8 @@ void EIO_Open(uv_work_t* req) {
     return;
   }
 
+  bufferSize = data->bufferSize;
+
   DCB dcb = { 0 };
   dcb.DCBlength = sizeof(DCB);
   if(!BuildCommDCB("9600,n,8,1", &dcb)) {
@@ -53,7 +55,6 @@ void EIO_Open(uv_work_t* req) {
   }
 
   dcb.fBinary = true;
-  dcb.fDtrControl = DTR_CONTROL_DISABLE;
   dcb.BaudRate = data->baudRate;
   dcb.ByteSize = data->dataBits;
   switch(data->parity) {
@@ -125,8 +126,8 @@ void EIO_WatchPort(uv_work_t* req) {
   while(true){
     OVERLAPPED ov = {0};
     ov.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
-
-    if(!ReadFile(data->fd, data->buffer, 100, &data->bytesRead, &ov)) {
+    
+    if(!ReadFile(data->fd, data->buffer, bufferSize, &data->bytesRead, &ov)) {
       data->errorCode = GetLastError();
       if(data->errorCode == ERROR_OPERATION_ABORTED) {
         data->disconnected = true;


### PR DESCRIPTION
This fixes some issues i was having with firmata on windows.  Windows now supports the bufferSize options.  It also resets the arduino like on linux/mac by not messing with DTR.
