### PR TITLE
bump node requirement 0.7.0 for libuv's uv_mutex_t

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chai": "*"
   },
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 0.7.0"
   },
   "bin": {
     "serialportlist": "./bin/serialportList.js",


### PR DESCRIPTION
uv_mutex_t was added to node via libuv in node 0.7.0.
Builds fail otherwise.  This doesn't seem to help my case, but 1.0.6, before the synching stuff seems ok.

```
bewest@ripen:~/Documents/git/node$ node -v
v0.6.17
bewest@ripen:~/Documents/git/node$ git log --graph -Suv_mutex_t working-2012-09-09...v0.6.21 
bewest@ripen:~/Documents/git/node$ 
bewest@ripen:~/Documents/git/node$ git log --graph -Suv_mutex_t working-2012-09-09...v0.7.0  | grep commit | wc
     10      39     518
```
# npm install

```
bewest@ripen:~/Documents/git/node-serialport$ npm install 

> serialport@1.0.7 install /home/bewest/Documents/git/node-serialport
> node-gyp rebuild

info it worked if it ends with ok 
spawn python [ '/home/bewest/.node-gyp/0.6.17/tools/gyp_addon',
  'binding.gyp',
  '-I/home/bewest/Documents/git/node-serialport/build/config.gypi',
  '-f',
  'make' ]
spawn make [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory `/home/bewest/Documents/git/node-serialport/build'
  CXX(target) Release/obj.target/serialport/src/serialport.o
../src/serialport.cpp:8: error: ‘uv_mutex_t’ does not name a type
../src/serialport.cpp: In function ‘v8::Handle<v8::Value> Open(const v8::Arguments&)’:
../src/serialport.cpp:14: error: ‘write_queue_mutex’ was not declared in this scope
../src/serialport.cpp:14: error: ‘uv_mutex_init’ was not declared in this scope
../src/serialport.cpp: In function ‘v8::Handle<v8::Value> Write(const v8::Arguments&)’:
../src/serialport.cpp:112: error: ‘write_queue_mutex’ was not declared in this scope
../src/serialport.cpp:112: error: ‘uv_mutex_lock’ was not declared in this scope
../src/serialport.cpp:120: error: ‘uv_mutex_unlock’ was not declared in this scope
../src/serialport.cpp: In function ‘void EIO_AfterWrite(uv_work_t*)’:
../src/serialport.cpp:139: error: ‘write_queue_mutex’ was not declared in this scope
../src/serialport.cpp:139: error: ‘uv_mutex_lock’ was not declared in this scope
../src/serialport.cpp:148: error: ‘uv_mutex_unlock’ was not declared in this scope
make: *** [Release/obj.target/serialport/src/serialport.o] Error 1
make: Leaving directory `/home/bewest/Documents/git/node-serialport/build'
ERR! Error: `make` failed with exit code: 2
    at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:209:23)
    at ChildProcess.emit (events.js:70:17)
    at maybeExit (child_process.js:362:16)
    at Process.onexit (child_process.js:398:5)
ERR! not ok

npm ERR! serialport@1.0.7 install: `node-gyp rebuild`
npm ERR! `sh "-c" "node-gyp rebuild"` failed with 1
npm ERR! 
npm ERR! Failed at the serialport@1.0.7 install script.
npm ERR! This is most likely a problem with the serialport package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls serialport
npm ERR! There is likely additional logging output above.
npm ERR! 
npm ERR! System Linux 2.6.32-42-generic
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /home/bewest/Documents/git/node-serialport
npm ERR! node -v v0.6.17
npm ERR! npm -v 1.1.21
npm ERR! code ELIFECYCLE
npm ERR! message serialport@1.0.7 install: `node-gyp rebuild`
npm ERR! message `sh "-c" "node-gyp rebuild"` failed with 1
npm ERR! errno {}
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/bewest/Documents/git/node-serialport/npm-debug.log
npm not ok
bewest@ripen:~/Documents/git/node-serialport$ 
```
