### PR TITLE
fix osx serialport.list issue

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -152,7 +152,7 @@ SerialPort.prototype.write = function (buffer, callback) {
 
 SerialPort.prototype.close = function (callback) {
   var self = this;
-  
+
   var fd = this.fd;
   this.fd = 0;
 
@@ -229,6 +229,7 @@ function listOSX (callback) {
     }
 
     var lines = stdout.split('\n');
+
     var items = [];
     var currentItem = {};
     lines.forEach(function (line) {
@@ -248,7 +249,7 @@ function listOSX (callback) {
         currentItem['manufacturer'] = m[1];
       } else if (/^$/.test(line)) {
         if ('serialNumber' in currentItem) {
-          currentItem['comName'] = "/dev/cu.usbserial-" + currentItem['serialNumber'];
+          currentItem['comName'] = "/dev/cu.usbmodem" + currentItem['locationId'].substring(2, 6) + '1';
           items.push(currentItem);
           currentItem = {};
         }


### PR DESCRIPTION
currently the serial number is used in conjunction with /dev/cu.usbserial\* (which i've never seen)

this patch uses part of the locationId string which matches the usual directory listing of /dev/{tty,cu}.usbmodem*

Here's a bit of a test..

```
node-serialport (master)‣ node -e "require('./serialport').list(console.log)"
null [ { productId: '0x8509',
    vendorId: '0x05ac  (Apple Inc.)',
    serialNumber: 'CC2B4U06HSDG6LL0',
    manufacturer: 'Apple Inc.',
    locationId: '0xfa200000 / 3',
    comName: '/dev/cu.usbserial-CC2B4U06HSDG6LL0' },
  { productId: '0x2044',
    vendorId: '0x03eb  (Atmel Corporation)',
    locationId: '0xfd120000 / 4',
    manufacturer: 'tmpvar',
    serialNumber: '64133343436351D05170',
    comName: '/dev/cu.usbserial-64133343436351D05170' } ]
node-serialport (master)‣ ls /dev/cu.usbserial-64133343436351D05170
ls: /dev/cu.usbserial-64133343436351D05170: No such file or directory
node-serialport (master)‣ git stash pop
# On branch master
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
# modified:   serialport.js
#
no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (0d5efe307f0e8e02716286d4151d666e04a1bc80)
node-serialport (master)‣ node -e "require('./serialport').list(console.log)"
null [ { productId: '0x8509',
    vendorId: '0x05ac  (Apple Inc.)',
    serialNumber: 'CC2B4U06HSDG6LL0',
    manufacturer: 'Apple Inc.',
    locationId: '0xfa200000 / 3',
    comName: '/dev/cu.usbmodemfa201' },
  { productId: '0x2044',
    vendorId: '0x03eb  (Atmel Corporation)',
    locationId: '0xfd120000 / 4',
    manufacturer: 'tmpvar',
    serialNumber: '64133343436351D05170',
    comName: '/dev/cu.usbmodemfd121' } ]
node-serialport (master)‣ ls /dev/cu.usbmodemfd121
/dev/cu.usbmodemfd121
```
