### PR TITLE
corrected list under Unix for multiple devices with the same ID

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -198,22 +198,37 @@ function listUnix (callback) {
       }
       return console.log(err);
     }
+    fs.readdir("/dev/serial/by-path", function(err_path, paths) {
+      if (err_path) {
+        if (err.errno === 34) return callback(null, []);
+        return console.log(err);
+      }
 
-    var dirName = "/dev/serial/by-id";
-    async.map(files, function (file, callback) {
-      var fileName = path.join(dirName, file);
-      fs.readlink(fileName, function (err, link) {
-        if (err) {
-          return callback(err);
-        }
-        link = path.resolve(dirName, link);
-        callback(null, {
-          comName: link,
-          manufacturer: undefined,
-          pnpId: file
+      var dirName, items;
+      //check if multiple devices of the same id are connected
+      if (files.length !== paths.length) {
+        dirName = "/dev/serial/by-path";
+        items = paths;
+      } else {
+        dirName = "/dev/serial/by-id";
+        items = files;
+      }
+
+      async.map(items, function (file, callback) {
+        var fileName = path.join(dirName, file);
+        fs.readlink(fileName, function (err, link) {
+          if (err) {
+            return callback(err);
+          }
+          link = path.resolve(dirName, link);
+          callback(null, {
+            comName: link,
+            manufacturer: undefined,
+            pnpId: file
+          });
         });
-      });
-    }, callback);
+      }, callback);
+    });
   });
 }
 


### PR DESCRIPTION
In a case where several identical devices are connected they show up with the same device-id therefore /dev/serial/by-id only detects one device.  Looking at /dev/serial/by-path reveals the actual number of devices.

the listUnix() function only accounts for by-id.  This pull request modifies the logic to query by by-id and by-path, compare the lengths.  If length is the same default to using the contents of by-id since it has meaningful device names.  if lengths are not the same use the contents of by-path.

I noticed this issue when I connected multiple USB 56K modems to a single server via a USB hub.

Roy
