### PR TITLE
package: remove "node-gyp" as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "async": "0.1.18",
     "sf": "0.1.3",
     "optimist": "~0.3.4",
-    "node-gyp": "0.6.2"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
npm bundles its own internal copy of node-gyp,
so installing another copy is not necessary.
