### PR TITLE
Sleep for 1s before calling tcflush

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -186,6 +186,7 @@ void EIO_Open(uv_work_t* req) {
   options.c_cc[VMIN]=1;
   options.c_cc[VTIME]=0;
 
+  sleep(1);
   tcflush(fd, TCIFLUSH);
   tcsetattr(fd, TCSANOW, &options);
 


### PR DESCRIPTION
The serial port was not flushed after opening. The fix is to sleep for 1s between open and calling tcflush. 
