### PR TITLE
Fixed an error to work with nodejs 0.10.0 on Windows

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -262,7 +262,7 @@ void AfterOpenSuccess(int fd, v8::Handle<v8::Value> dataCallback, v8::Handle<v8:
   uv_work_t* req = new uv_work_t();
   req->data = baton;
 
-  uv_queue_work(uv_default_loop(), req, EIO_WatchPort, EIO_AfterWatchPort);
+  uv_queue_work(uv_default_loop(), req, EIO_WatchPort, (uv_after_work_cb)EIO_AfterWatchPort);
 }
 
 void EIO_Write(uv_work_t* req) {


### PR DESCRIPTION
Fixed the error :
error C2664: 'uv_queue_work' : cannot convert parameter 4 from 'void
(__cdecl *)(uv_work_t *)' to 'uv_after_work_cb'
