### PR TITLE
Cast size_t to DWORD to avoid compiler warning.

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -1,4 +1,3 @@
-
 #include "serialport.h"
 #include <list>
 #include "win/disphelper.h"
@@ -278,7 +277,7 @@ void EIO_Write(uv_work_t* req) {
 
   // Start write operation - synchrounous or asynchronous
   DWORD bytesWrittenSync = 0;
-  if(!WriteFile((HANDLE)data->fd, data->bufferData, data->bufferLength, &bytesWrittenSync, &ov)) {
+  if(!WriteFile((HANDLE)data->fd, data->bufferData, static_cast<DWORD>(data->bufferLength), &bytesWrittenSync, &ov)) {
     DWORD lastError = GetLastError();
     if(lastError != ERROR_IO_PENDING) {
       // Write operation error


### PR DESCRIPTION
This doesn't change any functionality, but silences the following compiler warning (which occurs at least on Windows x64, not sure about elsewhere):

```
..\src\serialport_win.cpp(281): warning C4267: 'argument' : conversion from 'size_t' to 'DWORD', possible loss of data
[c:\Users\Domenic\Dropbox\Programming\WIP\nodebots\node_modules\serialport\build\serialport.vcxproj]
```
