### PR TITLE
Fix for flowControl not getting applied.

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -83,9 +83,8 @@ function SerialPort (path, options, openImmediately) {
   options.parity = options.parity || 'none';
   options.stopBits = options.stopBits || options.stopbits || 1;
   options.bufferSize = options.bufferSize || options.buffersize || 100;
-  if (!('flowControl' in options)) {
-    options.flowControl = false;
-  }
+  options.flowControl = options.flowControl || options.flowcontrol || false;
+
   options.dataCallback = function (data) {
     options.parser(self, data);
   };


### PR DESCRIPTION
This is a quick and easy fix. I was able to confirm functionality on OS X with TinyG (using test code for hardware flow control.) Since this only changes how the config parameter gets into the lower layers, it shouldn't create any (new ;-) issues.

-Rob
