### PR TITLE
Simplify win/enumser to reduce build dependencies

### DIFF
--- a/src/win/enumser.h
+++ b/src/win/enumser.h
@@ -171,9 +171,13 @@ public:
 
 protected:
 //Methods
+#if !defined(NO_ENUMSERIAL_USING_SETUPAPI1) || !defined(NO_ENUMSERIAL_USING_SETUPAPI2)
   static BOOL RegQueryValueString(HKEY kKey, LPCTSTR lpValueName, LPTSTR& pszValue);
   static BOOL QueryRegistryPortName(HKEY hDeviceKey, int& nPort);
+#endif
+#if !defined(NO_ENUMSERIAL_USING_SETUPAPI1) || !defined(NO_ENUMSERIAL_USING_SETUPAPI2) || !defined(NO_ENUMSERIAL_USING_COMDB)
   static HMODULE LoadLibraryFromSystem32(LPCTSTR lpFileName);
+#endif
   static BOOL IsNumeric(LPCSTR pszString, BOOL bIgnoreColon);
   static BOOL IsNumeric(LPCWSTR pszString, BOOL bIgnoreColon);
 };

--- a/src/win/stdafx.h
+++ b/src/win/stdafx.h
@@ -35,16 +35,15 @@
   #include <afxtempl.h>
   #include <atlbase.h>
 #else
-  #include <vector>
-  #include <string>
   #include "stdstring.h"
-  #define CString CStdString
   #define NO_ENUMSERIAL_USING_WMI
 #endif
 
-#include <setupapi.h>
-#include <malloc.h>
-#include <winspool.h>
-#include <Wbemcli.h>
-#include <comdef.h>
-#include <stdio.h>
+#define NO_ENUMSERIAL_USING_ENUMPORTS
+#define NO_ENUMSERIAL_USING_SETUPAPI1
+#define NO_ENUMSERIAL_USING_SETUPAPI2
+#define NO_ENUMSERIAL_USING_WMI
+#define NO_ENUMSERIAL_USING_COMDB
+#define NO_ENUMSERIAL_USING_CREATEFILE
+#define NO_ENUMSERIAL_USING_GETDEFAULTCOMMCONFIG
+#define NO_ENUMSERIAL_USING_REGISTRY


### PR DESCRIPTION
I looked at what was being called and what was not and removed the uncalled code.  This should help simplify dependencies and fixed a build break I was seeing with the latest release of node-gyp.  This may also help fix the compatibility issues with nw-gyp.
