### PR TITLE
FIX: Some windows 7 displays error when listing com ports

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -354,7 +354,7 @@ void EIO_List(uv_work_t* req) {
     DISPATCH_OBJ(colDevices);
 
     dhInitialize(TRUE);
-    dhToggleExceptions(TRUE);
+    dhToggleExceptions(FALSE);
    
     dhGetObject(L"winmgmts:{impersonationLevel=impersonate}!\\\\.\\root\\cimv2", NULL, &wmiSvc);
     dhGetValue(L"%o", &colDevices, wmiSvc, L".ExecQuery(%S)", L"Select * from Win32_PnPEntity");
@@ -369,7 +369,7 @@ void EIO_List(uv_work_t* req) {
       dhGetValue(L"%s", &name,  objDevice, L".Name");
       dhGetValue(L"%s", &pnpid, objDevice, L".PnPDeviceID");
                                                   
-      if( (match = strstr( name, "(COM" )) != NULL ) { // look for "(COM23)"
+      if( name != NULL && ((match = strstr( name, "(COM" )) != NULL) ) { // look for "(COM23)"
         // 'Manufacturuer' can be null, so only get it if we need it
         dhGetValue(L"%s", &manu, objDevice,  L".Manufacturer");
         port_count++;


### PR DESCRIPTION
On some windows machine alerts are shown, when something goes bad when
trying to list com ports. dhToggleExceptions(FALSE) turns those off.
But then, there is sometimes huge number of serial ports reported, which do not have their
name set. We check for the name existence and proceed only when it is
available. For us it fixes
https://github.com/voodootikigod/node-serialport/issues/169
reliably on multiple machines.

Disclaimer: I do not know what goes bad when trying to list COM ports using the com object calls, but this is what fixed it for us all broken machines (so far)
