### PR TITLE
Fix for truncated error messages on Windows

### DIFF
--- a/src/serialport.h
+++ b/src/serialport.h
@@ -25,6 +25,8 @@ enum SerialPortStopBits {
   SERIALPORT_STOPBITS_TWO = 3
 };
 
+#define ERROR_STRING_SIZE 1024
+
 v8::Handle<v8::Value> List(const v8::Arguments& args);
 void EIO_List(uv_work_t* req);
 void EIO_AfterList(uv_work_t* req);
@@ -63,7 +65,7 @@ public:
   bool flowControl;
   SerialPortParity parity;
   SerialPortStopBits stopBits;
-  char errorString[1024];
+  char errorString[ERROR_STRING_SIZE];
 };
 
 struct WriteBaton {
@@ -74,7 +76,7 @@ public:
   v8::Persistent<v8::Object> buffer;
   v8::Persistent<v8::Value> callback;
   int result;
-  char errorString[1024];
+  char errorString[ERROR_STRING_SIZE];
 };
 
 struct QueuedWrite {
@@ -88,7 +90,7 @@ struct CloseBaton {
 public:
   int fd;
   v8::Persistent<v8::Value> callback;
-  char errorString[1024];
+  char errorString[ERROR_STRING_SIZE];
 };
 
 struct ListResultItem {
@@ -106,7 +108,7 @@ struct ListBaton {
 public:
   v8::Persistent<v8::Value> callback;
   std::list<ListResultItem*> results;
-  char errorString[1024];
+  char errorString[ERROR_STRING_SIZE];
 };
 
 struct FlushBaton {
@@ -114,7 +116,7 @@ public:
   int fd;
   v8::Persistent<v8::Value> callback;
   int result;
-  char errorString[1024];
+  char errorString[ERROR_STRING_SIZE];
 };
 
 #endif

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -18,19 +18,19 @@ int bufferSize;
 void ErrorCodeToString(const char* prefix, int errorCode, char *errorStr) {
   switch(errorCode) {
   case ERROR_FILE_NOT_FOUND:
-    _snprintf(errorStr, sizeof(errorStr), "%s: File not found", prefix);
+    _snprintf(errorStr, ERROR_STRING_SIZE, "%s: File not found", prefix);
     break;
   case ERROR_INVALID_HANDLE:
-    _snprintf(errorStr, sizeof(errorStr), "%s: Invalid handle", prefix);
+    _snprintf(errorStr, ERROR_STRING_SIZE, "%s: Invalid handle", prefix);
     break;
   case ERROR_ACCESS_DENIED:
-    _snprintf(errorStr, sizeof(errorStr), "%s: Access denied", prefix);
+    _snprintf(errorStr, ERROR_STRING_SIZE, "%s: Access denied", prefix);
     break;
   case ERROR_OPERATION_ABORTED:
-    _snprintf(errorStr, sizeof(errorStr), "%s: operation aborted", prefix);
+    _snprintf(errorStr, ERROR_STRING_SIZE, "%s: operation aborted", prefix);
     break;
   default:
-    _snprintf(errorStr, sizeof(errorStr), "%s: Unknown error code %d", prefix, errorCode);
+    _snprintf(errorStr, ERROR_STRING_SIZE, "%s: Unknown error code %d", prefix, errorCode);
     break;
   }
 }
@@ -136,7 +136,7 @@ public:
   HANDLE fd;
   DWORD bytesRead;
   char buffer[MAX_BUFFER_SIZE];
-  char errorString[1000];
+  char errorString[ERROR_STRING_SIZE];
   DWORD errorCode;
   bool disconnected;
   v8::Persistent<v8::Value> dataCallback;


### PR DESCRIPTION
This fixes #204
This is serious bug on Windows, so please merge it. Tested building it only on Windows.
