### PR TITLE
readme: windows issue when installing to system32

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ This assumes you have everything on your system necessary to compile ANY native 
    npm install serialport --msvs_version=2012
 ```
 
-This switch works for both Visual Studio Express 2012 and 2013.
+This switch works for both Visual Studio Express 2012 and 2013. 
+
+Note: Make sure you've `cd`'d into the project directory -- the command prompt will open by default in `%SYSTEMROOT%`, and the install will fail there.
 
 ### Mac OS X:
 


### PR DESCRIPTION
I kept running into the following error

```
C:\WINDOWS\system32\node_modules\serialport>node "C:\Program Files\nodejs\node_m
odules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuil
d
gyp: binding.gyp not found (cwd: C:\WINDOWS\system32\node_modules\serialport) wh
ile trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (C:\Program Files\nodejs\node_module
s\npm\node_modules\node-gyp\lib\configure.js:416:16)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:99:17)
gyp ERR! stack     at Process._handle.onexit (child_process.js:678:10)
gyp ERR! System Windows_NT 6.2.9200
gyp ERR! command "node" "C:\\Program Files\\nodejs\\node_modules\\npm\\node_modu
les\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\WINDOWS\system32\node_modules\serialport
gyp ERR! node -v v0.8.19
gyp ERR! node-gyp -v v0.8.4
gyp ERR! not ok
npm ERR! serialport@1.1.3 install: `node-gyp rebuild`
npm ERR! `cmd "/c" "node-gyp rebuild"` failed with 1
npm ERR!
npm ERR! Failed at the serialport@1.1.3 install script.
npm ERR! This is most likely a problem with the serialport package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls serialport
npm ERR! There is likely additional logging output above.

npm ERR! System Windows_NT 6.2.9200
npm ERR! command "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nod
ejs\\node_modules\\npm\\bin\\npm-cli.js" "install" "serialport" "-msvs_version=2
012" "-python=C:\\python27\\python.exe"
npm ERR! cwd C:\WINDOWS\system32
npm ERR! node -v v0.8.19
npm ERR! npm -v 1.2.10
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     C:\WINDOWS\system32\npm-debug.log
npm ERR! not ok code 0
```

when trying to `npm install` by just opening the VS command prompt. `npm install -g` works fine, so I do believe it's because of trying to install it (accidentally) in the `%SYSTEMROOT%` folder. This is a stupid thing to do, but it took me a while to figure out what the issue was, so thought I'd add it to the readme.
