### PR TITLE
Parity shouldn't be changing data bits

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -166,21 +166,18 @@ void EIO_Open(uv_work_t* req) {
     options.c_cflag &= ~PARENB;
     options.c_cflag &= ~CSTOPB;
     options.c_cflag &= ~CSIZE;
-    options.c_cflag |= CS8;
     break;
   case SERIALPORT_PARITY_ODD:
     options.c_cflag |= PARENB;
     options.c_cflag |= PARODD;
     options.c_cflag &= ~CSTOPB;
     options.c_cflag &= ~CSIZE;
-    options.c_cflag |= CS7;
     break;
   case SERIALPORT_PARITY_EVEN:
     options.c_cflag |= PARENB;
     options.c_cflag &= ~PARODD;
     options.c_cflag &= ~CSTOPB;
     options.c_cflag &= ~CSIZE;
-    options.c_cflag |= CS7;
     break;
   default:
     snprintf(data->errorString, sizeof(data->errorString), "Invalid parity setting %d", data->parity);


### PR DESCRIPTION
This fixes a bug where the data bits parameter was being set to 7 for even and odd parity, even when it was specifically set to 8 by the user. For example, your data would have been mangled if you requested the following:

``` javascript
var serial = new SerialPort('/dev/ttyUSB0', {parity: 'even', dataBits: 8});
```
