### PR TITLE
Move to a separate device pool, fixes upstream #227

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -30,12 +30,6 @@ function SerialPortFactory() {
   // Stuff from ReadStream, refactored for our usage:
   var kPoolSize = 40 * 1024;
   var kMinPoolSpace = 128;
-  var pool;
-
-  function allocNewPool() {
-    pool = new Buffer(kPoolSize);
-    pool.used = 0;
-  }
 
   var parsers = {
     raw: function (emitter, buffer) {
@@ -281,19 +275,22 @@ function SerialPortFactory() {
 
       self.reading = true;
 
-      if (!pool || pool.length - pool.used < kMinPoolSpace) {
+      if (!self.pool || self.pool.length - self.pool.used < kMinPoolSpace) {
         // discard the old pool. Can't add to the free list because
         // users might have refernces to slices on it.
-        pool = null;
-        allocNewPool();
+        self.pool = null;
+
+        // alloc new pool
+        self.pool = new Buffer(kPoolSize);
+        self.pool.used = 0;
       }
 
       // Grab another reference to the pool in the case that while we're in the
       // thread pool another read() finishes up the pool, and allocates a new
       // one.
-      var thisPool = pool;
-      var toRead = Math.min(pool.length - pool.used, ~~self.bufferSize);
-      var start = pool.used;
+      var thisPool = self.pool;
+      var toRead = Math.min(self.pool.length - self.pool.used, ~~self.bufferSize);
+      var start = self.pool.used;
 
       function afterRead(err, bytesRead, readPool, bytesRequested) {
         self.reading = false;
@@ -310,7 +307,7 @@ function SerialPortFactory() {
 
         // Since we will often not read the number of bytes requested,
         // let's mark the ones we didn't need as available again.
-        pool.used -= bytesRequested - bytesRead;
+        self.pool.used -= bytesRequested - bytesRead;
 
         // console.log(">>ACTUALLY READ: ", bytesRead);
 
@@ -318,7 +315,7 @@ function SerialPortFactory() {
           if (self.fd >= 0)
             self.serialPoller.start();
         } else {
-          var b = thisPool.slice(start, start + bytesRead);
+          var b = self.pool.slice(start, start + bytesRead);
 
           // do not emit events if the stream is paused
           if (self.paused) {
@@ -335,14 +332,17 @@ function SerialPortFactory() {
         }
       }
 
+      // debug this device's pool offset
+      // console.log(self.path + ' >> POOL OFFSET: ', self.pool.used);
+
       // console.log(">>REQUEST READ: ", toRead);
-      fs.read(self.fd, pool, pool.used, toRead, self.pos, function(err, bytesRead){
-        var readPool = pool;
+      fs.read(self.fd, self.pool, self.pool.used, toRead, self.pos, function(err, bytesRead){
+        var readPool = self.pool;
         var bytesRequested = toRead;
         afterRead(err, bytesRead, readPool, bytesRequested);}
       );
 
-      pool.used += toRead;
+      self.pool.used += toRead;
     };
 
 


### PR DESCRIPTION
This fixes issue #227 by separating pools for each device in use. Only necessary if using > 1 port at the same time.
