### PR TITLE
use NAN for Node 0.8->0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,15 +5,24 @@
       'sources': [
         'src/serialport.cpp',
       ],
+      'include_dirs': [
+        '<!(node -e "require(\'nan\')")'
+      ],
       'conditions': [
         ['OS=="win"',
           {
             'sources': [
-              "src/serialport_win.cpp",
+              'src/serialport_win.cpp',
               'src/win/disphelper.c',
               'src/win/enumser.cpp',
             ],
-          }
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'ExceptionHandling': '2',
+                'DisableSpecificWarnings': [ '4530', '4506' ],
+              },
+            },
+          },
         ],
         ['OS!="win"',
           {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "bindings": "1.1.1",
     "async": "0.1.18",
     "sf": "0.1.6",
-    "optimist": "~0.3.4"
+    "optimist": "~0.3.4",
+    "nan": "~0.7.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,92 @@
+/* Copyright (c) 2013, Ben Noordhuis <info@bnoordhuis.nl>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef QUEUE_H_
+#define QUEUE_H_
+
+typedef void *QUEUE[2];
+
+/* Private macros. */
+#define QUEUE_NEXT(q)       (*(QUEUE **) &((*(q))[0]))
+#define QUEUE_PREV(q)       (*(QUEUE **) &((*(q))[1]))
+#define QUEUE_PREV_NEXT(q)  (QUEUE_NEXT(QUEUE_PREV(q)))
+#define QUEUE_NEXT_PREV(q)  (QUEUE_PREV(QUEUE_NEXT(q)))
+
+/* Public macros. */
+#define QUEUE_DATA(ptr, type, field)                                          \
+  ((type *) ((char *) (ptr) - ((char *) &((type *) 0)->field)))
+
+#define QUEUE_FOREACH(q, h)                                                   \
+  for ((q) = QUEUE_NEXT(h); (q) != (h); (q) = QUEUE_NEXT(q))
+
+#define QUEUE_EMPTY(q)                                                        \
+  ((const QUEUE *) (q) == (const QUEUE *) QUEUE_NEXT(q))
+
+#define QUEUE_HEAD(q)                                                         \
+  (QUEUE_NEXT(q))
+
+#define QUEUE_INIT(q)                                                         \
+  do {                                                                        \
+    QUEUE_NEXT(q) = (q);                                                      \
+    QUEUE_PREV(q) = (q);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_ADD(h, n)                                                       \
+  do {                                                                        \
+    QUEUE_PREV_NEXT(h) = QUEUE_NEXT(n);                                       \
+    QUEUE_NEXT_PREV(n) = QUEUE_PREV(h);                                       \
+    QUEUE_PREV(h) = QUEUE_PREV(n);                                            \
+    QUEUE_PREV_NEXT(h) = (h);                                                 \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_SPLIT(h, q, n)                                                  \
+  do {                                                                        \
+    QUEUE_PREV(n) = QUEUE_PREV(h);                                            \
+    QUEUE_PREV_NEXT(n) = (n);                                                 \
+    QUEUE_NEXT(n) = (q);                                                      \
+    QUEUE_PREV(h) = QUEUE_PREV(q);                                            \
+    QUEUE_PREV_NEXT(h) = (h);                                                 \
+    QUEUE_PREV(q) = (n);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_INSERT_HEAD(h, q)                                               \
+  do {                                                                        \
+    QUEUE_NEXT(q) = QUEUE_NEXT(h);                                            \
+    QUEUE_PREV(q) = (h);                                                      \
+    QUEUE_NEXT_PREV(q) = (q);                                                 \
+    QUEUE_NEXT(h) = (q);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_INSERT_TAIL(h, q)                                               \
+  do {                                                                        \
+    QUEUE_NEXT(q) = (h);                                                      \
+    QUEUE_PREV(q) = QUEUE_PREV(h);                                            \
+    QUEUE_PREV_NEXT(q) = (q);                                                 \
+    QUEUE_PREV(h) = (q);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_REMOVE(q)                                                       \
+  do {                                                                        \
+    QUEUE_PREV_NEXT(q) = QUEUE_NEXT(q);                                       \
+    QUEUE_NEXT_PREV(q) = QUEUE_PREV(q);                                       \
+  }                                                                           \
+  while (0)
+
+#endif /* QUEUE_H_ */

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -2,14 +2,13 @@
 #ifndef _serialport_h_
 #define _serialport_h_
 
-#include <node.h>
-#include <v8.h>
-#include <node_buffer.h>
+#include <nan.h>
 #include <list>
 #include <string>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "queue.h"
 
 enum SerialPortParity {
   SERIALPORT_PARITY_NONE = 1,
@@ -27,28 +26,28 @@ enum SerialPortStopBits {
 
 #define ERROR_STRING_SIZE 1024
 
-v8::Handle<v8::Value> List(const v8::Arguments& args);
+NAN_METHOD(List);
 void EIO_List(uv_work_t* req);
 void EIO_AfterList(uv_work_t* req);
 
-v8::Handle<v8::Value> Open(const v8::Arguments& args);
+NAN_METHOD(Open);
 void EIO_Open(uv_work_t* req);
 void EIO_AfterOpen(uv_work_t* req);
-void AfterOpenSuccess(int fd, v8::Handle<v8::Value> dataCallback, v8::Handle<v8::Value> disconnectedCallback, v8::Handle<v8::Value> errorCallback);
+void AfterOpenSuccess(int fd, NanCallback* dataCallback, NanCallback* disconnectedCallback, NanCallback* errorCallback);
 
-v8::Handle<v8::Value> Write(const v8::Arguments& args);
+NAN_METHOD(Write);
 void EIO_Write(uv_work_t* req);
 void EIO_AfterWrite(uv_work_t* req);
 
-v8::Handle<v8::Value> Close(const v8::Arguments& args);
+NAN_METHOD(Close);
 void EIO_Close(uv_work_t* req);
 void EIO_AfterClose(uv_work_t* req);
 
-v8::Handle<v8::Value> Flush(const v8::Arguments& args);
+NAN_METHOD(Flush);
 void EIO_Flush(uv_work_t* req);
 void EIO_AfterFlush(uv_work_t* req);
 
-v8::Handle<v8::Value> Drain(const v8::Arguments& args);
+NAN_METHOD(Drain);
 void EIO_Drain(uv_work_t* req);
 void EIO_AfterDrain(uv_work_t* req);
 
@@ -58,10 +57,10 @@ SerialPortStopBits ToStopBitEnum(double stopBits);
 struct OpenBaton {
 public:
   char path[1024];
-  v8::Persistent<v8::Value> callback;
-  v8::Persistent<v8::Value> dataCallback;
-  v8::Persistent<v8::Value> disconnectedCallback;
-  v8::Persistent<v8::Value> errorCallback;
+  NanCallback* callback;
+  NanCallback* dataCallback;
+  NanCallback* disconnectedCallback;
+  NanCallback* errorCallback;
   int result;
   int baudRate;
   int dataBits;
@@ -83,7 +82,7 @@ public:
   size_t bufferLength;
   size_t offset;
   v8::Persistent<v8::Object> buffer;
-  v8::Persistent<v8::Value> callback;
+  NanCallback* callback;
   int result;
   char errorString[ERROR_STRING_SIZE];
 };
@@ -91,14 +90,14 @@ public:
 struct QueuedWrite {
 public:
   uv_work_t req;
-  ngx_queue_t queue;
+  QUEUE queue;
   WriteBaton* baton;
 };
 
 struct CloseBaton {
 public:
   int fd;
-  v8::Persistent<v8::Value> callback;
+  NanCallback* callback;
   char errorString[ERROR_STRING_SIZE];
 };
 
@@ -115,7 +114,7 @@ public:
 
 struct ListBaton {
 public:
-  v8::Persistent<v8::Value> callback;
+  NanCallback* callback;
   std::list<ListResultItem*> results;
   char errorString[ERROR_STRING_SIZE];
 };
@@ -123,7 +122,7 @@ public:
 struct FlushBaton {
 public:
   int fd;
-  v8::Persistent<v8::Value> callback;
+  NanCallback* callback;
   int result;
   char errorString[ERROR_STRING_SIZE];
 };
@@ -131,7 +130,7 @@ public:
 struct DrainBaton {
 public:
   int fd;
-  v8::Persistent<v8::Value> callback;
+  NanCallback* callback;
   int result;
   char errorString[ERROR_STRING_SIZE];
 };

--- a/src/serialport_poller.h
+++ b/src/serialport_poller.h
@@ -5,7 +5,7 @@
 #ifndef SERIALPORT_POLLER_H
 #define SERIALPORT_POLLER_H
 
-#include <node.h>
+#include <nan.h>
 
 class SerialportPoller : public node::ObjectWrap {
  public:
@@ -20,14 +20,14 @@ class SerialportPoller : public node::ObjectWrap {
   SerialportPoller();
   ~SerialportPoller();
 
-  static v8::Handle<v8::Value> New(const v8::Arguments& args);
-  static v8::Handle<v8::Value> Close(const v8::Arguments& args);
-  static v8::Handle<v8::Value> Start(const v8::Arguments& args);
+  static NAN_METHOD(New);
+  static NAN_METHOD(Close);
+  static NAN_METHOD(Start);
   
   uv_poll_t poll_handle_;
   int fd_;
 
-  v8::Persistent<v8::Function> callback_;
+  NanCallback* callback_;
 };
 
 #endif

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -33,8 +33,10 @@ int ToBaudConstant(int baudRate);
 int ToDataBitsConstant(int dataBits);
 int ToStopBitsConstant(SerialPortStopBits stopBits);
 
-void AfterOpenSuccess(int fd, v8::Handle<v8::Value> dataCallback, v8::Handle<v8::Value> disconnectedCallback, v8::Handle<v8::Value> errorCallback) {
-
+void AfterOpenSuccess(int fd, NanCallback* dataCallback, NanCallback* disconnectedCallback, NanCallback* errorCallback) {
+  delete dataCallback;
+  delete errorCallback;
+  delete disconnectedCallback;
 }
 
 int ToBaudConstant(int baudRate) {


### PR DESCRIPTION
I know a similar PR has been submitted previously but I'm having a go now because we're getting late in the 0.11 cycle and it'd be nice to start playing with serialport on 0.11.

V8 instability isn't going to improve post-0.12 and most of the instability for native addons comes from V8's major changes and have almost nothing to do with Node. This is where NAN comes in, we're maintaining an abstraction between V8 & Node and native add-ons where the breakages happen and continue to adapt as more breakages happen and will do so beyond 0.12.
