### PR TITLE
Add example to demonstrate drain()

### DIFF
--- a/examples/drain.js
+++ b/examples/drain.js
@@ -1,8 +1,8 @@
 var SerialPort = require("serialport").SerialPort;
 
 var sp = new SerialPort("/dev/cu.Cubelet-RGB", {
-    baudrate: 38400
-  });
+  baudrate: 38400
+});
 
 sp.on('open',function() {
   sp.on('data', function(data) {
@@ -39,7 +39,7 @@ sp.on('open',function() {
   };
 
   // Stuff starts happening here
-  writeThenDrainThenWait();
-  //writeThenWait();
+  writeThenDrainThenWait(1000);
+  //writeThenWait(1000);
 
 });


### PR DESCRIPTION
The example here will send a bunch of echo requests, call drain to block until the requests have "left the pipe", wait for a duration, then repeat. Can be useful for dead-reckoning scenarios where you need to send some data, wait for it to leave the port's write queue, and wait a specific period of time before repeating another write.
