### PR TITLE
Move parsers to their own file because they don't rely on anything else.

### DIFF
--- a/parsers.js
+++ b/parsers.js
@@ -1,0 +1,28 @@
+/*jslint node: true */
+"use strict";
+
+// Copyright 2011 Chris Williams <chris@iterativedesigns.com>
+
+var parsers = module.exports = {
+  raw: function (emitter, buffer) {
+    emitter.emit("data", buffer);
+  },
+  //encoding: ascii utf8 utf16le ucs2 base64 binary hex
+  //More: http://nodejs.org/api/buffer.html#buffer_buffer
+  readline: function (delimiter, encoding) {
+    if (typeof delimiter === "undefined" || delimiter === null) { delimiter = "\r"; }
+    if (typeof encoding  === "undefined" || encoding  === null) { encoding  = "utf8"; }
+    // Delimiter buffer saved in closure
+    var data = "";
+    return function (emitter, buffer) {
+      // Collect data
+      data += buffer.toString(encoding);
+      // Split collected data by delimiter
+      var parts = data.split(delimiter);
+      data = parts.pop();
+      parts.forEach(function (part, i, array) {
+        emitter.emit('data', part);
+      });
+    };
+  }
+};

--- a/serialport.js
+++ b/serialport.js
@@ -4,6 +4,7 @@
 // Copyright 2011 Chris Williams <chris@iterativedesigns.com>
 
 var SerialPortBinding = require("bindings")("serialport.node");
+var parsers = require('./parsers');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var fs = require('fs');
@@ -28,30 +29,6 @@ function SerialPortFactory() {
   // Stuff from ReadStream, refactored for our usage:
   var kPoolSize = 40 * 1024;
   var kMinPoolSpace = 128;
-
-  var parsers = {
-    raw: function (emitter, buffer) {
-      emitter.emit("data", buffer);
-    },
-    //encoding: ascii utf8 utf16le ucs2 base64 binary hex
-    //More: http://nodejs.org/api/buffer.html#buffer_buffer
-    readline: function (delimiter, encoding) {
-      if (typeof delimiter === "undefined" || delimiter === null) { delimiter = "\r"; }
-      if (typeof encoding  === "undefined" || encoding  === null) { encoding  = "utf8"; }
-      // Delimiter buffer saved in closure
-      var data = "";
-      return function (emitter, buffer) {
-        // Collect data
-        data += buffer.toString(encoding);
-        // Split collected data by delimiter
-        var parts = data.split(delimiter);
-        data = parts.pop();
-        parts.forEach(function (part, i, array) {
-          emitter.emit('data', part);
-        });
-      };
-    }
-  };
 
   // The default options, can be overwritten in the 'SerialPort' constructor
   var _options = {

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -1,11 +1,10 @@
 "use strict";
 
-var serialPort = require('../serialport');
 var chai = require('chai');
 var sinonChai = require("sinon-chai");
 var sinon = require("sinon");
 
-var parsers = serialPort.parsers;
+var parsers = require('../parsers');
 
 describe("parsers", function () {
 


### PR DESCRIPTION
Not only do they not rely on anything else, they probably shouldn't rely on anything else. I'm hankering to reduce coupling related complexity and this is a start.
