### PR TITLE
don't set options on a callback open function

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -77,7 +77,8 @@ function SerialPortFactory() {
       callback = null;
     }
 
-    options = options || {};
+    options = (typeof options !== 'function') && options || {};
+
     openImmediately = (openImmediately === undefined || openImmediately === null) ? true : openImmediately;
 
     stream.Stream.call(this);

--- a/test/serialport-basic.js
+++ b/test/serialport-basic.js
@@ -50,6 +50,13 @@ describe('SerialPort', function () {
       var port = new SerialPort('/dev/exists', { databits : 19 }, false, errorCallback);
     });
 
+    it('allows optional options', function (done) {
+      var cb = function () {};
+      var port = new SerialPort('/dev/exists', cb);
+      expect(typeof port.options).to.eq('object');
+      done();
+    });
+
   });
 
   describe('reading data', function () {


### PR DESCRIPTION
I don't even want to know what trouble this could cause.
