### PR TITLE
Add missing flags for OS X 10.9 & node 0.11

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,19 @@
             },
           },
         ],
+        ['OS=="mac"',
+          {
+            'sources': [
+              'src/serialport_unix.cpp',
+              'src/serialport_poller.cpp',
+            ],
+            'xcode_settings': {
+              'OTHER_LDFLAGS': [
+                '-framework CoreFoundation -framework IOKit'
+              ]
+            }
+          }
+        ],
         ['OS!="win"',
           {
             'sources': [


### PR DESCRIPTION
serialport builds fine on OS X 10.9 Mavericks with node 0.11 and 0.10, but at runtime I get this error on node 0.11 only

``` javascript
// index.js
var SerialPort = require('serialport').SerialPort;
```

```
node index.js

/Users/luigy/code/test/node_modules/serialport/node_modules/bindings/bindings.js:83
        throw e
              ^
Error: dlopen(/Users/luigy/code/test/node_modules/serialport/build/Release/serialport.node, 1): Symbol not found: ___CFConstantStringClassReference
  Referenced from: /Users/luigy/code/test/node_modules/serialport/build/Release/serialport.node
  Expected in: dynamic lookup

    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
    at Module.require (module.js:357:17)
    at require (module.js:373:17)
    at bindings (/Users/luigy/code/test/node_modules/serialport/node_modules/bindings/bindings.js:76:44)
    at Object.<anonymous> (/Users/luigy/code/test/node_modules/serialport/serialport.js:6:44)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
```
