### PR TITLE
fix tests on node v0.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "0.8"
+  - "0.9"
   - "0.10"
   - "0.11"
 compiler: clang

--- a/test_mocks/linux-hardware.js
+++ b/test_mocks/linux-hardware.js
@@ -130,6 +130,9 @@ Hardware.prototype.fakeRead = function (path, buffer, offset, length, position, 
   if ((offset + length) > buffer.length) {
     throw new Error("Length extends beyond buffer");
   }
+
+  // node v0.8 doesn't like a slice that is bigger then available data
+  length = port.data.length < length ? port.data.length : length;
   var read = port.data.slice(0, length);
   port.data = port.data.slice(length);
   read.copy(buffer, offset);
@@ -137,7 +140,6 @@ Hardware.prototype.fakeRead = function (path, buffer, offset, length, position, 
 };
 
 var hardware = new Hardware();
-
 
 var SandboxedModule = require('sandboxed-module');
 


### PR DESCRIPTION
Run travis on all versions of node, fix a difference in `buffer.slice()` between versions
