### PR TITLE
Add Makefile and 'release' task.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ release:
 	@git checkout master
 
 	@echo "Publishing to NPM"
-	@npm push ./
+	@npm publish ./


### PR DESCRIPTION
This PR adds a `Makefile`, which includes a `release` task to do the following things:
- make a new git tag with the current version specified in `package.json`
- push the new tag to GitHub
- checkout the `osx-node-pre-gyp` branch, merge master into it, and push to GitHub (to tell Travis to make a new binary)
- publish latest master to NPM

Example invocation:

```
$ make release
Tagging release 1.3.1
Pushing tags to GitHub
Switching to osx-node-pre-gyp branch
Merging master into osx-node-pre-gyp
Pushing osx-node-pre-gyp
Switching to master branch
Publishing to NPM
```

This is 3rd PR referenced in [this comment](https://github.com/voodootikigod/node-serialport/issues/290#issuecomment-39625224).
