### PR TITLE
Add [publish binary] message to release task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ release:
 	@git checkout osx-node-pre-gyp
 
 	@echo "Merging master into osx-node-pre-gyp"
-	@git merge master
+	@git merge --no-ff --commit -m "Merge master into osx-node-pre-gyp [publish binary]" master
 
 	@echo "Pushing osx-node-pre-gyp"
 	@git push


### PR DESCRIPTION
With these Makefile changes, merging `master` into `osx-node-pre-gyp` during the
`make release` task will:
- always force a commit.
- add a "[publish binary]" message to the commit to tell Travis to build and publish a new binary.
