### PR TITLE
Issue 401: fix ToParityEnum

### DIFF
--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -395,7 +395,7 @@ SerialPortParity NAN_INLINE(ToParityEnum(const v8::Handle<v8::String>& v8str)) {
   NanScope();
 
 
-  NanUtf8String *str = new nanUtf8String(v8str);
+  NanUtf8String *str = new NanUtf8String(v8str);
   size_t count = strlen(**str);
 
   SerialPortParity parity = SERIALPORT_PARITY_NONE;


### PR DESCRIPTION
The parity param is not well cast in ToParityEnum method (Issue 401).

This link describe the right usage of NanUtf8String : https://github.com/rvagg/nan#api_nan_utf8_string
