### PR TITLE
Fixing flush() and drain() without callback

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -515,7 +515,9 @@ function SerialPortFactory() {
           self.emit('error', err);
         }
       } else {
-        callback(err, result);
+        if (callback) {
+          callback(err, result);
+        }
       }
     });
   };
@@ -542,7 +544,9 @@ function SerialPortFactory() {
           self.emit('error', err);
         }
       } else {
-        callback(err, result);
+        if (callback) {
+          callback(err, result);
+        }
       }
     });
   };


### PR DESCRIPTION
Calling port.flush() or port.drain() methods fails when there is no callback provided.
