### PR TITLE
Linux binding: Collect Symlinks

### DIFF
--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -78,10 +78,10 @@ function listLinux() {
         }
         return
       }
-	  
+
       // gather symlinks
       if (lineType === 'S') {
-        port['symlinks'].push('/dev/' + data)
+        port['symlinks'].push(`/dev/${data}`)
       }
 
       // parse data about each port

--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -59,6 +59,7 @@ function listLinux() {
           locationId: undefined,
           vendorId: undefined,
           productId: undefined,
+          symlinks: [],
         }
         skipPort = false
         return
@@ -76,6 +77,11 @@ function listLinux() {
           skipPort = true
         }
         return
+      }
+	  
+      // gather symlinks
+      if (lineType === 'S') {
+        port['symlinks'].push('/dev/' + data)
       }
 
       // parse data about each port


### PR DESCRIPTION
Hi everybody,

this is a suggestion (for linux systems with udev), how symlinks can be transparently added to the serial device list without breaking anything (or so I hope). (See  #1476)

The port objects simply gets an additional property, an array with all symlinks for this device. Since this does not expand the actual returned list, support needs to be implemented in every project that wants to use a symlink...