### PR TITLE
Fixed RTS/CTS flow control for Windows

### DIFF
--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -125,7 +125,8 @@ void EIO_Open(uv_work_t* req) {
   }
 
   if (data->rtscts) {
-    dcb.fRtsControl = RTS_CONTROL_ENABLE;
+    dcb.fRtsControl = RTS_CONTROL_HANDSHAKE;
+    dcb.fOutxCtsFlow = TRUE;
   } else {
     dcb.fRtsControl = RTS_CONTROL_DISABLE;
   }


### PR DESCRIPTION
The previous implementation of RTS/CTS flow control would hold the RTS line high and ignore the CTS line.

This corrects those two issues.  When the RTS/CTS option is enabled, the serial port will now not send data to the remote device until the CTS line is low, and will lower the RTS line when the input buffer is more than three-quarters full (as per [this document](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/ns-winbase-_dcb)).