### PR TITLE
support Exar ttyXRUSB

### DIFF
--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -3,7 +3,7 @@ const Readline = require('@serialport/parser-readline')
 
 // get only serial port names
 function checkPathOfDevice(path) {
-  return /(tty(S|WCH|ACM|USB|AMA|MFD|O)|rfcomm)/.test(path) && path
+  return /(tty(S|WCH|ACM|USB|AMA|MFD|O|XRUSB)|rfcomm)/.test(path) && path
 }
 
 function propName(name) {


### PR DESCRIPTION
support for Exar serial devices

```
➜  ~ ls /dev/ttyXRUSB*
/dev/ttyXRUSB0  /dev/ttyXRUSB1  /dev/ttyXRUSB2  /dev/ttyXRUSB3  /dev/ttyXRUSB4  /dev/ttyXRUSB5  /dev/ttyXRUSB6  /dev/ttyXRUSB7
```