### PR TITLE
chore: reset info.serialNumber when resetting mock ports

### DIFF
--- a/packages/binding-mock/binding-mock.js
+++ b/packages/binding-mock/binding-mock.js
@@ -26,6 +26,7 @@ class MockBinding extends AbstractBinding {
   // Reset mocks
   static reset() {
     ports = {}
+    serialNumber = 0
   }
 
   // Create a mock port

--- a/packages/binding-mock/binding-mock.test.js
+++ b/packages/binding-mock/binding-mock.test.js
@@ -1,10 +1,100 @@
-/* eslint-disable no-new */
-
 const BindingMock = require('./binding-mock')
+
+// copypasta from bindings/lib/bindings.test.js
+function shouldReject(promise, errType = Error, message = 'Should have rejected') {
+  return promise.then(
+    () => {
+      throw new Error(message)
+    },
+    err => {
+      assert.instanceOf(err, errType)
+    }
+  )
+}
 
 describe('BindingMock', () => {
   it('constructs', () => {
     new BindingMock({})
   })
   it('needs more testing')
+
+  describe('instance method', () => {
+    beforeEach(function() {
+      this.binding = new BindingMock({})
+    })
+
+    describe('open', () => {
+      describe('when phony port not created', () => {
+        it('should reject', function() {
+          return shouldReject(this.binding.open('/dev/ttyUSB0', {}))
+        })
+      })
+
+      describe('when phony port created', () => {
+        beforeEach(() => {
+          BindingMock.createPort('/dev/ttyUSB0')
+        })
+
+        afterEach(() => {
+          BindingMock.reset()
+        })
+
+        it('should open the phony port', async function() {
+          await this.binding.open('/dev/ttyUSB0', {})
+          assert.isTrue(this.binding.isOpen)
+        })
+
+        it('should have a "port" prop with "info.serialNumber" prop', async function() {
+          await this.binding.open('/dev/ttyUSB0', {})
+          assert.strictEqual(this.binding.port.info.serialNumber, 1)
+        })
+      })
+    })
+  })
+
+  describe('static method', () => {
+    describe('createPort', () => {
+      afterEach(() => {
+        BindingMock.reset()
+      })
+
+      it('should increment the serialNumber', async () => {
+        BindingMock.createPort('/dev/ttyUSB0')
+        BindingMock.createPort('/dev/ttyUSB1')
+        const binding1 = new BindingMock({})
+        await binding1.open('/dev/ttyUSB0', {})
+        const binding2 = new BindingMock({})
+        await binding2.open('/dev/ttyUSB1', {})
+        assert.strictEqual(binding2.port.info.serialNumber, 2)
+      })
+    })
+    describe('reset', () => {
+      beforeEach(async function() {
+        BindingMock.createPort('/dev/ttyUSB0')
+        this.binding = new BindingMock({})
+        await this.binding.open('/dev/ttyUSB0', {})
+        assert.strictEqual(this.binding.port.info.serialNumber, 1)
+        await this.binding.close()
+      })
+
+      afterEach(async function() {
+        // speculative cleanup
+        try {
+          await this.binding.close()
+        } catch (ignored) {}
+      })
+
+      it('should delete any configured phony ports', function() {
+        BindingMock.reset()
+        return shouldReject(this.binding.open('/dev/ttyUSB0', {}))
+      })
+
+      it('should reset the serialNumber assigned to the phony port', async function() {
+        BindingMock.reset()
+        BindingMock.createPort('/dev/ttyUSB0')
+        await this.binding.open('/dev/ttyUSB0', {})
+        assert.strictEqual(this.binding.port.info.serialNumber, 1)
+      })
+    })
+  })
 })


### PR DESCRIPTION
BREAKING CHANGE

Resetting the value in the phony port's `info.serialNumber` property
when `BindingMock.reset()` is called will make its behavior "more
deterministic." This is useful when doing deep-equality checks against a
`BindingMock` instance (or more specifically, a `SerialPort` instance
containing a `BindingMock` instance); judicious use of
`BindingMock.reset()` will mean a developer can expect the value of
`info.serialNumber` to be deterministic when tests are run in any order
or in isolation.

People have a tendency to code their way around stuff like this, so this
is _potentially_ a breaking change for _somebody somewhere._