### PR TITLE
Fix writing issue on Linux with v8.0.0

### DIFF
--- a/packages/bindings/lib/unix-write.js
+++ b/packages/bindings/lib/unix-write.js
@@ -19,13 +19,13 @@ module.exports = async function unixWrite(buffer, offset) {
     throw new Error('Port is not open')
   }
   try {
-    const bytesWritten = await writeAsync(this.fd, buffer, offset, bytesToWrite)
+    const { bytesWritten } = await writeAsync(this.fd, buffer, offset, bytesToWrite)
     logger('write returned: wrote', bytesWritten, 'bytes')
     if (bytesWritten + offset < buffer.length) {
       if (!this.isOpen) {
         throw new Error('Port is not open')
       }
-      return resolve(unixWrite.call(this, buffer, bytesWritten + offset))
+      return unixWrite.call(this, buffer, bytesWritten + offset)
     }
 
     logger('Finished writing', bytesWritten + offset, 'bytes')


### PR DESCRIPTION
Hi,

there is an issue on Linux when writing to the serial port with new 8.0.0 version. It sends only one chunk and stops sending others. The problem is that the return value of `writeAsync` is changed and there is an unnecessary `resolve` in the `unixWrite` function. This PR fixes this issue. Tested on Linux ARM. 