### PR TITLE
Make it possible to compile on vanilla Android

### DIFF
--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -3,3 +3,11 @@
 The `Binding` is how Node-SerialPort talks to the underlying system. By default, we auto detect Windows, Linux and OS X, and load the appropriate module for your system. You can assign `SerialPort.Binding` to any binding you like. Find more by searching ["serialport-binding" at npm](https://www.npmjs.com/search?q=serialport-binding).
 
 Learn more at our [bindings documentation](https://serialport.io/docs/api-bindings) page.
+
+# Android users
+
+When using termux there is a way to compile serialport to be used under Android
+
+```sh
+CFLAGS=-fPIC CXXFLAGS=-fPIC yarn rebuild
+```

--- a/packages/bindings/binding.gyp
+++ b/packages/bindings/binding.gyp
@@ -45,6 +45,15 @@
           ]
         }
       ],
+      ['OS=="android"',
+        {
+          'sources': [
+            'src/serialport_unix.cpp',
+            'src/poller.cpp',
+            'src/serialport_linux.cpp'
+          ]
+        }
+      ],
       ['OS!="win"',
         {
           'sources': [


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee2mqtt/issues/1861
Adding support for Android and default -fPIC not -fPIE make serial port working on Android + Termux ( https://play.google.com/store/apps/details?id=com.termux )
