### PR TITLE
chore: Setup CI with github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [push]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    # https://github.com/nodejs/node-gyp/issues/1663#issuecomment-535049449
+    - name: patch node gyp on windows to support Visual Studio 2019
+      if: matrix.os == 'windows-latest'
+      shell: powershell
+      run: |
+        npm install --global node-gyp@latest
+        npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+    - name: npm install
+      run: npm install
+    - name: npm run rebuild
+      run: npm run rebuild
+    - name: npm test
+      run: npm test
+    - name: coverage
+      run: npm run coverage
+      env:
+        CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,10 @@ env:
   matrix:
   - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8"
   - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
-  - TRAVIS_NODE_VERSION="10"
-  - TRAVIS_NODE_VERSION="12"
 matrix:
   exclude:
   - os: osx
-    env: TRAVIS_NODE_VERSION="6" ARCH="x86"
-  - os: osx
     env: BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
-  - os: osx
-    env: TRAVIS_NODE_VERSION="9" ARCH="x86"
 
 before_install:
 
@@ -69,15 +63,10 @@ install:
 - npm run rebuild
 
 script:
-- npm test
-
 # if publishing, do it
 - >
   if [[ $PUBLISH_BINARY == true ]]; then
     echo "building and uploading binaries"
     npm run prebuild;
   fi;
-
-after_success:
-- npm run coverage
-
+  true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ environment:
   matrix:
   - nodejs_version: "8"
     binary_builder: "true"
-  - nodejs_version: "10"
-  - nodejs_version: "12"
 
 platform:
 - x86
@@ -47,15 +45,10 @@ build_script:
 - npm run rebuild
 
 test_script:
-- npm test
-
 - ps: >
     if ($env:publish_binary -eq "true") {
       npm run prebuild
     }
     true;
-
-after_test:
-- npm run coverage
 
 deploy: OFF

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,5 @@ parsers:
 coverage:
   status:
     patch: off
+codecov:
+  token: 262a74e1-f31b-4cd4-a6a1-cdb25c5c2285


### PR DESCRIPTION
This uses GitHub actions for linux and osx testing. Windows doesn’t work yet so appveryor remains the same. Travis is still present for binary building.

Todo:
- [x] codecov token