### PR TITLE
feat: add end event for piping

### DIFF
--- a/packages/stream/stream.js
+++ b/packages/stream/stream.js
@@ -10,6 +10,7 @@ const FLOWCONTROLS = Object.freeze(['xon', 'xoff', 'xany', 'rtscts'])
 
 const defaultSettings = Object.freeze({
   autoOpen: true,
+  endOnClose: false,
   baudRate: 9600,
   dataBits: 8,
   hupcl: true,
@@ -432,6 +433,9 @@ SerialPort.prototype.close = function(callback, disconnectError) {
       this.closing = false
       debug('binding.close', 'finished')
       this.emit('close', disconnectError)
+      if (this.settings.endOnClose) {
+        this.emit('end')
+      }
       if (callback) {
         callback.call(this, disconnectError)
       }

--- a/packages/stream/stream.test.js
+++ b/packages/stream/stream.test.js
@@ -439,13 +439,34 @@ describe('SerialPort', () => {
     })
 
     describe('#close', () => {
-      it('emits a close event', done => {
+      it('emits a close event for writing consumers', done => {
         const port = new SerialPort('/dev/exists', () => {
           port.on('close', () => {
             assert.isFalse(port.isOpen)
             done()
           })
           port.close()
+        })
+      })
+
+      it('emits an "end" event for reading consumers when endOnClose is true', done => {
+        const port = new SerialPort('/dev/exists', { endOnClose: true })
+        port.on('open', () => {
+          port.on('end', () => {
+            assert.isFalse(port.isOpen)
+            done()
+          })
+          port.close()
+        })
+      })
+
+      it('doesn\'t emit an "end" event for reading consumers when endOnClose is false', done => {
+        const port = new SerialPort('/dev/exists')
+        port.on('open', () => {
+          port.on('end', () => {
+            done(new Error('Should not have ended'))
+          })
+          port.close(() => done())
         })
       })
 


### PR DESCRIPTION
This will allow streams to end. We haven't done this because it allows a stream to be reopened and data to be continued to be read. This may not be a good idea but I'm opening this issue for discussion.

Maybe we should have this as an option?