### PR TITLE
fix: stop polling if the poller has an error

### DIFF
--- a/packages/bindings/lib/poller.js
+++ b/packages/bindings/lib/poller.js
@@ -1,12 +1,12 @@
 const debug = require('debug')
 const logger = debug('serialport/bindings/poller')
 const EventEmitter = require('events')
-const FDPoller = require('bindings')('bindings.node').Poller
+const PollerBindings = require('bindings')('bindings.node').Poller
 
 const EVENTS = {
-  UV_READABLE: 1,
-  UV_WRITABLE: 2,
-  UV_DISCONNECT: 4,
+  UV_READABLE: 0b0001,
+  UV_WRITABLE: 0b0010,
+  UV_DISCONNECT: 0b0100,
 }
 
 function handleEvent(error, eventFlag) {
@@ -35,7 +35,7 @@ function handleEvent(error, eventFlag) {
  * Polls unix systems for readable or writable states of a file or serialport
  */
 class Poller extends EventEmitter {
-  constructor(fd) {
+  constructor(fd, FDPoller = PollerBindings) {
     logger('Creating poller')
     super()
     this.poller = new FDPoller(fd, handleEvent.bind(this))

--- a/packages/bindings/lib/poller.test.js
+++ b/packages/bindings/lib/poller.test.js
@@ -1,0 +1,60 @@
+const Poller = require('./poller')
+
+class MockPollerBidnings {
+  constructor(fd, callback) {
+    this.fd = fd
+    this.callback = callback
+  }
+  poll(flag) {
+    this.lastPollFlag = flag
+    setImmediate(() => this.callback(null, flag))
+  }
+}
+
+class ErrorPollerBindings {
+  constructor(fd, callback) {
+    this.fd = fd
+    this.callback = callback
+  }
+  poll(flag) {
+    this.lastPollFlag = flag
+    setImmediate(() => this.callback(new Error('oh no!'), flag))
+  }
+}
+
+describe('Poller', () => {
+  it('constructs', () => {
+    new Poller(1, MockPollerBidnings)
+  })
+  it('can listen to the readable event', done => {
+    const poller = new Poller(1, MockPollerBidnings)
+    poller.once('readable', err => {
+      assert.equal(err, null)
+      assert.equal(poller.poller.lastPollFlag, 1)
+      done(err)
+    })
+  })
+  it('can listen to the writable event', done => {
+    const poller = new Poller(1, MockPollerBidnings)
+    poller.once('writable', err => {
+      assert.equal(err, null)
+      assert.equal(poller.poller.lastPollFlag, 2)
+      done(err)
+    })
+  })
+  it('can listen to the disconnect event', done => {
+    const poller = new Poller(1, MockPollerBidnings)
+    poller.once('disconnect', err => {
+      assert.equal(err, null)
+      assert.equal(poller.poller.lastPollFlag, 4)
+      done(err)
+    })
+  })
+  it('reports errors on callback', done => {
+    const poller = new Poller(1, ErrorPollerBindings)
+    poller.once('readable', err => {
+      assert.notEqual(err, null)
+      done()
+    })
+  })
+})

--- a/packages/bindings/src/poller.h
+++ b/packages/bindings/src/poller.h
@@ -22,6 +22,7 @@ class Poller : public Nan::ObjectWrap, public Nan::AsyncResource {
   ~Poller();
   void poll(int events);
   void stop();
+  int _stop();
 
   static NAN_METHOD(New);
   static NAN_METHOD(poll);


### PR DESCRIPTION
This will stop polling for FS events if there’s an error polling for fs events. Added tests for the JS. Tests for the c++ are harder.

This supersedes #1804 and ensures no more events are fired if one reports an error. Fixes #1803 based upon @nfrasser's work.