### PR TITLE
fix: unix reading

### DIFF
--- a/packages/bindings/lib/bindings.test.js
+++ b/packages/bindings/lib/bindings.test.js
@@ -347,7 +347,7 @@ function testBinding(bindingName, Binding, testPort) {
           noZalgo = true
         })
 
-        it('throws when not given a buffer', async () => {
+        it('rejects when not given a buffer', async () => {
           const binding = new Binding({
             disconnect,
           })

--- a/packages/bindings/lib/unix-read.js
+++ b/packages/bindings/lib/unix-read.js
@@ -18,13 +18,13 @@ module.exports = async function unixRead(buffer, offset, length) {
   }
 
   try {
-    const bytesRead = await readAsync(this.fd, buffer, offset, length, null)
+    const { bytesRead } = await readAsync(this.fd, buffer, offset, length, null)
     if (bytesRead === 0) {
       return this.read(buffer, offset, length)
     }
 
     logger('Finished read', bytesRead, 'bytes')
-    return bytesRead
+    return { bytesRead, buffer }
   } catch (err) {
     if (err.code === 'EAGAIN' || err.code === 'EWOULDBLOCK' || err.code === 'EINTR') {
       if (!this.isOpen) {


### PR DESCRIPTION
Another casualty of the async function refactor. This did fail the arudino tests.