### PR TITLE
chore: Update terminal to use stream and bindings

### DIFF
--- a/packages/terminal/lib/index.js
+++ b/packages/terminal/lib/index.js
@@ -1,9 +1,10 @@
 // #!/usr/bin/env node
 const { Select } = require('enquirer')
 const args = require('commander')
-const SerialPort = require('serialport')
+const SerialPort = require('@serialport/stream')
 const { version } = require('../package.json')
 const { OutputTranslator } = require('./output-translator')
+SerialPort.Binding = require('@serialport/bindings')
 
 const makeNumber = input => Number(input)
 

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "commander": "^3.0.2",
     "enquirer": "^2.3.2",
-    "serialport": "^8.0.5"
+    "@serialport/bindings": "^8.0.4",
+    "@serialport/stream": "^8.0.4"
   },
   "engines": {
     "node": ">=8.6.0"


### PR DESCRIPTION
This keeps any update of any parser (which isn’t used) from updating this package.