### PR TITLE
fix: stream required bindings-mock as a dep

### DIFF
--- a/packages/serialport/package-lock.json
+++ b/packages/serialport/package-lock.json
@@ -4,11 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@serialport/parser-cctalk": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-3.0.0.tgz",
-			"integrity": "sha512-gDUpIqgJ0M5LjEm5ye0G15/LuVxdhQnVctukbQFwKD65t3d6dQzv3ikKWmaWslozr/6alnjdsmJJYqANoI6BKw=="
-		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -3,8 +3,10 @@
   "version": "8.0.4",
   "main": "lib",
   "dependencies": {
-    "@serialport/binding-mock": "^8.0.4",
     "debug": "^4.1.1"
+  },
+  "devDependencies": {
+    "@serialport/binding-mock": "^8.0.4"
   },
   "engines": {
     "node": ">=8.6.0"


### PR DESCRIPTION
It is indeed a dev-dep. Only effects people not using `@serialport/stream` directly.