### PR TITLE
chore: improve our linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": [
+    "eslint:recommended",
     "plugin:node/recommended",
     "plugin:mocha/recommended"
   ],
@@ -24,33 +25,22 @@
     "makeTestFeature": false
   },
   "rules": {
-    "no-process-exit": 0,
-    "no-unused-vars": [
-      2,
-      {
-        "vars": "all",
-        "args": "after-used"
-      }
-    ],
-    "no-var": 2,
-    "node/no-extraneous-require": 0,
-    "node/no-unpublished-require": 0,
-    "node/no-unsupported-features/es-builtins": [
-      2
-    ],
-    "node/no-unsupported-features/es-syntax": [
-      2
-    ],
-    "node/no-unsupported-features/node-builtins": [
-      2
-    ],
-    "node/shebang": 0,
-    "object-shorthand": 2,
-    "prefer-arrow-callback": 2,
-    "prefer-const": 2,
-    "prefer-template": 2,
+    "no-extra-semi": "off",
+    "no-process-exit": "off",
+    "no-unused-vars": [ "error", { "vars": "all", "args": "after-used" }],
+    "no-var": "error",
+    "node/no-extraneous-require": "off",
+    "node/no-unpublished-require": "off",
+    "node/no-unsupported-features/es-builtins": "error",
+    "node/no-unsupported-features/es-syntax": "error",
+    "node/no-unsupported-features/node-builtins": "error",
+    "node/shebang": "off",
+    "object-shorthand": "error",
+    "prefer-arrow-callback": "error",
+    "prefer-const": "error",
+    "prefer-template": "error",
     "prettier/prettier": [
-      2,
+      "error",
       {
         "singleQuote": true,
         "trailingComma": "es5",
@@ -58,16 +48,12 @@
         "printWidth": 150
       }
     ],
-    "strict": [
-      2,
-      "never"
-    ],
-    "valid-jsdoc": [
-      0
-    ],
-    "mocha/no-mocha-arrows": [0],
-    "mocha/no-setup-in-describe": [0],
-    "mocha/no-hooks-for-single-case": [0],
-    "mocha/no-exclusive-tests": [2]
+    "mocha/no-exclusive-tests": "error",
+    "mocha/no-hooks-for-single-case": "off",
+    "mocha/no-mocha-arrows": "off",
+    "mocha/no-pending-tests": "error",
+    "mocha/no-setup-in-describe": "off",
+    "strict": [ "error", "never" ],
+    "valid-jsdoc": "off"
   }
 }

--- a/packages/binding-mock/lib/index.test.js
+++ b/packages/binding-mock/lib/index.test.js
@@ -80,7 +80,9 @@ describe('BindingMock', () => {
         // speculative cleanup
         try {
           await this.binding.close()
-        } catch (ignored) {}
+        } catch (ignored) {
+          // ignored
+        }
       })
 
       it('should delete any configured phony ports', function() {

--- a/packages/terminal/lib/index.js
+++ b/packages/terminal/lib/index.js
@@ -23,7 +23,7 @@ args
 
 const listPorts = async () => {
   const ports = await SerialPort.list()
-  for (port of ports) {
+  for (const port of ports) {
     console.log(`${port.path}\t${port.pnpId || ''}\t${port.manufacturer || ''}`)
   }
 }


### PR DESCRIPTION
- makes the config file easier to understand
- bring in eslint:recommended
- finally we have `no-use-before-define` which finds a specific class of bugs we’ve suffered from