### PR TITLE
chore: change bindings constructor option to be optional

### DIFF
--- a/packages/binding-abstract/lib/index.js
+++ b/packages/binding-abstract/lib/index.js
@@ -29,7 +29,7 @@ class AbstractBinding {
     debug('list')
   }
 
-  constructor(opt) {
+  constructor(opt = {}) {
     if (typeof opt !== 'object') {
       throw new TypeError('"options" is not an object')
     }

--- a/packages/binding-mock/lib/index.js
+++ b/packages/binding-mock/lib/index.js
@@ -19,7 +19,7 @@ const cancelError = message => {
  * Mock bindings for pretend serialport access
  */
 class MockBinding extends AbstractBinding {
-  constructor(opt) {
+  constructor(opt = {}) {
     super(opt)
     this.pendingRead = null // thunk for a promise or null
     this.isOpen = false

--- a/packages/bindings/lib/bindings.test.js
+++ b/packages/bindings/lib/bindings.test.js
@@ -37,7 +37,7 @@ const bindingsToTest = ['mock', platform]
 
 // All bindings are required to work with an "echo" firmware
 // The echo firmware should respond with this data when it's
-// ready to echo. This allows for remote device bootup.
+// ready to echo. This allows for remote device boot up.
 // the default firmware is called arduinoEcho.ino
 const readyData = Buffer.from('READY')
 
@@ -92,17 +92,18 @@ function testBinding(bindingName, Binding, testPort) {
 
     describe('constructor', () => {
       it('creates a binding object', () => {
-        const binding = new Binding({})
+        const binding = new Binding()
         assert.instanceOf(binding, Binding)
       })
 
-      it('throws when not given an options object', done => {
+      it('throws when given something weird', () => {
         try {
-          new Binding()
+          new Binding(4)
         } catch (e) {
           assert.instanceOf(e, TypeError)
-          done()
+          return
         }
+        throw new Error('Should have errored')
       })
     })
 
@@ -115,7 +116,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
         })
 
         it('is true after open and false after close', () => {
@@ -134,7 +135,7 @@ function testBinding(bindingName, Binding, testPort) {
       describe('#open', () => {
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
         })
 
         it('errors when providing a bad port', async () => {
@@ -191,7 +192,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         describe('optional locking', () => {
           it('locks the port by default', async () => {
-            const binding2 = new Binding({})
+            const binding2 = new Binding()
             await binding.open(testPort, defaultOpenOptions)
             assert.equal(binding.isOpen, true)
             await shouldReject(binding2.open(testPort, defaultOpenOptions))
@@ -201,7 +202,7 @@ function testBinding(bindingName, Binding, testPort) {
 
           testFeature('open.unlock', 'can unlock the port', async () => {
             const noLock = { ...defaultOpenOptions, lock: false }
-            const binding2 = new Binding({})
+            const binding2 = new Binding()
 
             await binding.open(testPort, noLock)
             assert.equal(binding.isOpen, true)
@@ -217,7 +218,7 @@ function testBinding(bindingName, Binding, testPort) {
       describe('#close', () => {
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
         })
 
         it('errors when already closed', async () => {
@@ -239,12 +240,12 @@ function testBinding(bindingName, Binding, testPort) {
 
       describe('#update', () => {
         it('throws when not given an object', async () => {
-          const binding = new Binding({})
+          const binding = new Binding()
           await shouldReject(binding.update(), TypeError)
         })
 
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           let noZalgo = false
           binding.update({ baudRate: 9600 }).catch(err => {
             assert.instanceOf(err, Error)
@@ -261,7 +262,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
           return binding.open(testPort, defaultOpenOptions)
         })
 
@@ -282,7 +283,7 @@ function testBinding(bindingName, Binding, testPort) {
 
       describe('#write', () => {
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           let noZalgo = false
           binding
             .write(Buffer.from([]))
@@ -302,7 +303,7 @@ function testBinding(bindingName, Binding, testPort) {
         })
 
         it('rejects when not given a buffer', async () => {
-          const binding = new Binding({})
+          const binding = new Binding()
           await shouldReject(binding.write(null), TypeError)
         })
 
@@ -313,7 +314,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
           return binding.open(testPort, defaultOpenOptions)
         })
 
@@ -338,7 +339,7 @@ function testBinding(bindingName, Binding, testPort) {
 
       describe('#drain', () => {
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           let noZalgo = false
           binding.drain().catch(err => {
             assert.instanceOf(err, Error)
@@ -355,7 +356,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
           return binding.open(testPort, defaultOpenOptions)
         })
 
@@ -384,7 +385,7 @@ function testBinding(bindingName, Binding, testPort) {
 
       describe('#flush', () => {
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           let noZalgo = false
           binding.flush().catch(err => {
             assert.instanceOf(err, Error)
@@ -401,7 +402,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
           return binding.open(testPort, defaultOpenOptions)
         })
 
@@ -414,7 +415,7 @@ function testBinding(bindingName, Binding, testPort) {
 
       describe('#set', () => {
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           let noZalgo = false
           binding.set(defaultSetFlags).catch(err => {
             assert.instanceOf(err, Error)
@@ -425,7 +426,7 @@ function testBinding(bindingName, Binding, testPort) {
         })
 
         it('throws when not called with options', async () => {
-          const binding = new Binding({})
+          const binding = new Binding()
           await shouldReject(binding.set(() => {}), TypeError)
         })
 
@@ -436,7 +437,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
           return binding.open(testPort, defaultOpenOptions)
         })
 
@@ -451,7 +452,7 @@ function testBinding(bindingName, Binding, testPort) {
       // is left over on the pipe and isn't cleared when flushed on unix
       describe('#read', () => {
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           const buffer = Buffer.alloc(5)
           let noZalgo = false
           binding.read(buffer, 0, buffer.length).catch(err => {
@@ -470,7 +471,7 @@ function testBinding(bindingName, Binding, testPort) {
         let binding, buffer
         beforeEach(async () => {
           buffer = Buffer.alloc(readyData.length)
-          binding = new Binding({})
+          binding = new Binding()
           await binding.open(testPort, defaultOpenOptions)
         })
 
@@ -501,7 +502,7 @@ function testBinding(bindingName, Binding, testPort) {
 
       describe('#get', () => {
         it('errors asynchronously when not open', done => {
-          const binding = new Binding({})
+          const binding = new Binding()
           let noZalgo = false
           binding.get().catch(err => {
             assert.instanceOf(err, Error)
@@ -518,7 +519,7 @@ function testBinding(bindingName, Binding, testPort) {
 
         let binding
         beforeEach(() => {
-          binding = new Binding({})
+          binding = new Binding()
           return binding.open(testPort, defaultOpenOptions)
         })
 

--- a/packages/bindings/lib/darwin.js
+++ b/packages/bindings/lib/darwin.js
@@ -29,7 +29,7 @@ class DarwinBinding extends AbstractBinding {
     return wrapWithHiddenComName(asyncList())
   }
 
-  constructor(opt) {
+  constructor(opt = {}) {
     super(opt)
     this.bindingOptions = { ...defaultBindingOptions, ...opt.bindingOptions }
     this.fd = null

--- a/packages/bindings/lib/linux.js
+++ b/packages/bindings/lib/linux.js
@@ -29,7 +29,7 @@ class LinuxBinding extends AbstractBinding {
     return wrapWithHiddenComName(linuxList())
   }
 
-  constructor(opt) {
+  constructor(opt = {}) {
     super(opt)
     this.bindingOptions = { ...defaultBindingOptions, ...opt.bindingOptions }
     this.fd = null

--- a/packages/bindings/lib/win32.js
+++ b/packages/bindings/lib/win32.js
@@ -39,7 +39,7 @@ class WindowsBinding extends AbstractBinding {
     )
   }
 
-  constructor(opt) {
+  constructor(opt = {}) {
     super(opt)
     this.bindingOptions = { ...opt.bindingOptions }
     this.fd = null


### PR DESCRIPTION
It's easily used this way. I wonder if this is breaking?