### PR TITLE
fix: write errors would always disconnect

### DIFF
--- a/packages/stream/lib/index.js
+++ b/packages/stream/lib/index.js
@@ -321,7 +321,7 @@ SerialPort.prototype._write = function(data, encoding, callback) {
     },
     err => {
       debug('binding.write', 'error', err)
-      if (!err.canceled) {
+      if (err.disconnect) {
         this._disconnected(err)
       }
       callback(err)


### PR DESCRIPTION
I’m not convinced that there are many write errors that aren’t disconnect errors. But in any case we don’t have a canceled property on any write errors. The effect of this change is that maybe we won’t disconnect on all write errors and instead we’ll emit the error and probably crash the nodejs process because stream error handling is tough.

Needs tests and thought.