### PR TITLE
fix: reject on non-zero exit codes

### DIFF
--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -42,7 +42,7 @@ function listLinux() {
     const ports = []
     const ude = childProcess.spawn('udevadm', ['info', '-e'])
     const lines = ude.stdout.pipe(new Readline())
-    ude.on('close', code => code && reject(new Error(`List exited with code: ${code}`)))
+    ude.on('close', code => code && reject(new Error(`Error listing ports udevadm exited with error code: ${code}`)))
     ude.on('error', reject)
     lines.on('error', reject)
 

--- a/packages/bindings/lib/linux-list.js
+++ b/packages/bindings/lib/linux-list.js
@@ -42,6 +42,7 @@ function listLinux() {
     const ports = []
     const ude = childProcess.spawn('udevadm', ['info', '-e'])
     const lines = ude.stdout.pipe(new Readline())
+    ude.on('close', code => code && reject(new Error(`List exited with code: ${code}`)))
     ude.on('error', reject)
     lines.on('error', reject)
 

--- a/packages/bindings/lib/linux-list.test.js
+++ b/packages/bindings/lib/linux-list.test.js
@@ -113,4 +113,18 @@ describe('listLinux', () => {
       assert.containSubset(ports, portOutput)
     })
   })
+
+  it('rejects on non-zero exit codes', () => {
+    const list = listLinux()
+    listLinux.emit('close', 1)
+
+    list.then(
+      () => {
+        assert.fail('should not resolve for non-zero exit codes')
+      },
+      error => {
+        assert(error, new Error('List exited with code: 1'))
+      }
+    )
+  })
 })

--- a/packages/bindings/lib/linux-list.test.js
+++ b/packages/bindings/lib/linux-list.test.js
@@ -123,7 +123,7 @@ describe('listLinux', () => {
         assert.fail('should not resolve for non-zero exit codes')
       },
       error => {
-        assert(error, new Error('List exited with code: 1'))
+        assert(error, new Error('Error listing ports udevadm exited with error code: 1'))
       }
     )
   })

--- a/packages/bindings/lib/mocks/linux-list.js
+++ b/packages/bindings/lib/mocks/linux-list.js
@@ -4,13 +4,14 @@ const EventEmitter = require('events')
 const proxyquire = require('proxyquire')
 const Readable = require('stream').Readable
 let mockPorts
+let event
 
 proxyquire.noPreserveCache()
 const listLinux = proxyquire('../linux-list', {
   child_process: {
     spawn() {
-      const event = new EventEmitter()
       const stream = new Readable()
+      event = new EventEmitter()
       event.stdout = stream
       stream.push(mockPorts)
       stream.push(null)
@@ -22,6 +23,10 @@ proxyquire.preserveCache()
 
 listLinux.setPorts = ports => {
   mockPorts = ports
+}
+
+listLinux.emit = function() {
+  event.emit.apply(event, arguments)
 }
 
 listLinux.reset = () => {


### PR DESCRIPTION
`udevadm` does not expose errors when exporting the database ([yet](https://github.com/systemd/systemd/pull/14960)). But it does exit with `code > 0`, if no errors are exposed the exit code can still be used to provide feedback even if generic rather than just returning an empty array.

Happy to change the thrown error message if it does not match requirements.

Background: https://github.com/systemd/systemd/issues/14959 wrong permissions on any device that `udevadm` attempts to list will throw `EACCES`. These errors are not shown but `strace` will show an exit code `1`