### PR TITLE
chore: build on node 14 and drop node 8 and 32bit linux builds

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js 12
+    - name: Use Node.js 14
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
     - name: upgrade npm
       run: npm install -g npm
     - name: npm install

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # chances are that we'll never break on a merge to master on just one version of node
-        node-version: [12.x]
+        node-version: [14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,7 @@ env:
   global:
   - secure: "L+AGMJc5NAsuym+xzB4FWj0c2rCobosixkoxLBhDBVkLiYsMtfS9y1w8Xz0pbWKJnJAH9tfwHluu5aX2qYk2HbreSyNzy8hbPW+9RbSyAQexeiZG4mLuDEz0xvlpCCQBsS1OfMypQk0/JvL4oA9B/xasrpkeVuPI7dwAz2WcFms="
   matrix:
-  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8"
-  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
-matrix:
-  exclude:
-  - os: osx
-    env: BINARY_BUILDER="true" TRAVIS_NODE_VERSION="8" ARCH="x86"
+  - BINARY_BUILDER="true" TRAVIS_NODE_VERSION="14"
 
 before_install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     secure: iDcAJCYgJK4tffyzEHbMVR8DatJcIN8eY0h29p9JQkl43TcEcm6Z6JLOBpGDk1MJ
 
   matrix:
-  - nodejs_version: "8"
+  - nodejs_version: "14"
     binary_builder: "true"
 
 platform:

--- a/packages/bindings/lib/mocks/linux-list.js
+++ b/packages/bindings/lib/mocks/linux-list.js
@@ -30,7 +30,7 @@ listLinux.emit = () => {
 }
 
 listLinux.reset = () => {
-  mockPorts = {}
+  mockPorts = undefined
 }
 
 module.exports = listLinux


### PR DESCRIPTION
- Build binaries on node 14 and test on node 14
- Node 14 is no longer being built for 32bit linux, not much I can do.
- Node 8 is out of LTS so it’s gone https://github.com/nodejs/Release#release-schedule

BREAKING CHANGE: Dropping node 8 and 32bit linux builds