### PR TITLE
Add preferUnplugged to keep the main package plugged in Yarn 2

### DIFF
--- a/packages/serialport/package.json
+++ b/packages/serialport/package.json
@@ -63,5 +63,6 @@
   "scripts": {
     "repl": "node bin/repl.js",
     "postinstall": "node thank-you.js"
-  }
+  },
+  "preferUnplugged": false
 }


### PR DESCRIPTION
The `postinstall` causes Yarn to assume that the package might have a build step and Yarn ends up unplugging it, [which is undesirable](https://yarnpkg.com/advanced/lifecycle-scripts#a-note-about-postinstall). `preferUnplugged` is documented [here](https://yarnpkg.com/configuration/manifest#preferUnplugged).