### PR TITLE
Added low_latency mode for linux

### DIFF
--- a/packages/binding-abstract/lib/index.js
+++ b/packages/binding-abstract/lib/index.js
@@ -155,6 +155,7 @@ The in progress writes must error when the port is closed with an error object t
    * @param {Boolean} [options.dsr=false] flag for dsr
    * @param {Boolean} [options.dtr=true] flag for dtr
    * @param {Boolean} [options.rts=true] flag for rts
+   * @param {Boolean} [options.low_latency=false] flag for low_latency mode on Linux
    * @returns {Promise} Resolves once the port's flags are set.
    * @rejects {TypeError} When given invalid arguments, a `TypeError` is rejected.
    */

--- a/packages/binding-abstract/lib/index.js
+++ b/packages/binding-abstract/lib/index.js
@@ -155,7 +155,7 @@ The in progress writes must error when the port is closed with an error object t
    * @param {Boolean} [options.dsr=false] flag for dsr
    * @param {Boolean} [options.dtr=true] flag for dtr
    * @param {Boolean} [options.rts=true] flag for rts
-   * @param {Boolean} [options.low_latency=false] flag for low_latency mode on Linux
+   * @param {Boolean} [options.lowLatency=false] flag for lowLatency mode on Linux
    * @returns {Promise} Resolves once the port's flags are set.
    * @rejects {TypeError} When given invalid arguments, a `TypeError` is rejected.
    */

--- a/packages/bindings/lib/bindings.test.js
+++ b/packages/bindings/lib/bindings.test.js
@@ -29,6 +29,7 @@ const defaultSetFlags = Object.freeze({
   dtr: true,
   dts: false,
   rts: true,
+  low_latency: false,
 })
 
 const listFields = ['path', 'manufacturer', 'serialNumber', 'pnpId', 'locationId', 'vendorId', 'productId']

--- a/packages/bindings/lib/bindings.test.js
+++ b/packages/bindings/lib/bindings.test.js
@@ -29,7 +29,7 @@ const defaultSetFlags = Object.freeze({
   dtr: true,
   dts: false,
   rts: true,
-  low_latency: false,
+  lowLatency: false,
 })
 
 const listFields = ['path', 'manufacturer', 'serialNumber', 'pnpId', 'locationId', 'vendorId', 'productId']

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -264,6 +264,7 @@ NAN_METHOD(Set) {
   baton->cts = getBoolFromObject(options, "cts");
   baton->dtr = getBoolFromObject(options, "dtr");
   baton->dsr = getBoolFromObject(options, "dsr");
+  baton->low_latency = getBoolFromObject(options, "low_latency");
 
   uv_work_t* req = new uv_work_t();
   req->data = baton;
@@ -307,6 +308,7 @@ NAN_METHOD(Get) {
   baton->cts = false;
   baton->dsr = false;
   baton->dcd = false;
+  baton->low_latency = false;
   baton->callback.Reset(info[1].As<v8::Function>());
 
   uv_work_t* req = new uv_work_t();
@@ -329,6 +331,7 @@ void EIO_AfterGet(uv_work_t* req) {
     Nan::Set(results, Nan::New<v8::String>("cts").ToLocalChecked(), Nan::New<v8::Boolean>(data->cts));
     Nan::Set(results, Nan::New<v8::String>("dsr").ToLocalChecked(), Nan::New<v8::Boolean>(data->dsr));
     Nan::Set(results, Nan::New<v8::String>("dcd").ToLocalChecked(), Nan::New<v8::Boolean>(data->dcd));
+    Nan::Set(results, Nan::New<v8::String>("low_latency").ToLocalChecked(), Nan::New<v8::Boolean>(data->low_latency));
 
     argv[0] = Nan::Null();
     argv[1] = results;

--- a/packages/bindings/src/serialport.cpp
+++ b/packages/bindings/src/serialport.cpp
@@ -264,7 +264,7 @@ NAN_METHOD(Set) {
   baton->cts = getBoolFromObject(options, "cts");
   baton->dtr = getBoolFromObject(options, "dtr");
   baton->dsr = getBoolFromObject(options, "dsr");
-  baton->low_latency = getBoolFromObject(options, "low_latency");
+  baton->lowLatency = getBoolFromObject(options, "lowLatency");
 
   uv_work_t* req = new uv_work_t();
   req->data = baton;
@@ -308,7 +308,7 @@ NAN_METHOD(Get) {
   baton->cts = false;
   baton->dsr = false;
   baton->dcd = false;
-  baton->low_latency = false;
+  baton->lowLatency = false;
   baton->callback.Reset(info[1].As<v8::Function>());
 
   uv_work_t* req = new uv_work_t();
@@ -331,7 +331,7 @@ void EIO_AfterGet(uv_work_t* req) {
     Nan::Set(results, Nan::New<v8::String>("cts").ToLocalChecked(), Nan::New<v8::Boolean>(data->cts));
     Nan::Set(results, Nan::New<v8::String>("dsr").ToLocalChecked(), Nan::New<v8::Boolean>(data->dsr));
     Nan::Set(results, Nan::New<v8::String>("dcd").ToLocalChecked(), Nan::New<v8::Boolean>(data->dcd));
-    Nan::Set(results, Nan::New<v8::String>("low_latency").ToLocalChecked(), Nan::New<v8::Boolean>(data->low_latency));
+    Nan::Set(results, Nan::New<v8::String>("lowLatency").ToLocalChecked(), Nan::New<v8::Boolean>(data->lowLatency));
 
     argv[0] = Nan::Null();
     argv[1] = results;

--- a/packages/bindings/src/serialport.h
+++ b/packages/bindings/src/serialport.h
@@ -105,6 +105,7 @@ struct SetBaton : public Nan::AsyncResource {
   bool dtr = false;
   bool dsr = false;
   bool brk = false;
+  bool low_latency = false;
 };
 
 struct GetBaton : public Nan::AsyncResource {
@@ -115,6 +116,7 @@ struct GetBaton : public Nan::AsyncResource {
   bool cts = false;
   bool dsr = false;
   bool dcd = false;
+  bool low_latency = false;
 };
 
 struct GetBaudRateBaton : public Nan::AsyncResource {

--- a/packages/bindings/src/serialport.h
+++ b/packages/bindings/src/serialport.h
@@ -105,7 +105,7 @@ struct SetBaton : public Nan::AsyncResource {
   bool dtr = false;
   bool dsr = false;
   bool brk = false;
-  bool low_latency = false;
+  bool lowLatency = false;
 };
 
 struct GetBaton : public Nan::AsyncResource {
@@ -116,7 +116,7 @@ struct GetBaton : public Nan::AsyncResource {
   bool cts = false;
   bool dsr = false;
   bool dcd = false;
-  bool low_latency = false;
+  bool lowLatency = false;
 };
 
 struct GetBaudRateBaton : public Nan::AsyncResource {

--- a/packages/bindings/src/serialport_linux.cpp
+++ b/packages/bindings/src/serialport_linux.cpp
@@ -3,6 +3,7 @@
 #include <sys/ioctl.h>
 #include <asm/ioctls.h>
 #include <asm/termbits.h>
+#include <linux/serial.h>
 
 // Uses the termios2 interface to set nonstandard baud rates
 int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate) {
@@ -32,6 +33,26 @@ int linuxGetSystemBaudRate(const int fd, int* const outbaud) {
   }
 
   *outbaud = static_cast<int>(t.c_ospeed);
+
+  return 0;
+}
+
+int linuxSetLowLatencyMode(const int fd, const bool enable) {
+  struct serial_struct ss;
+
+  if (ioctl(fd, TIOCGSERIAL, &ss)) {
+    return -1;
+  }
+
+  if (enable) {
+    ss.flags |= ASYNC_LOW_LATENCY;
+  } else {
+    ss.flags &= ~ASYNC_LOW_LATENCY;
+  }
+
+  if (ioctl(fd, TIOCSSERIAL, &ss)) {
+    return -2;
+  }
 
   return 0;
 }

--- a/packages/bindings/src/serialport_linux.h
+++ b/packages/bindings/src/serialport_linux.h
@@ -3,6 +3,7 @@
 
 int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate);
 int linuxGetSystemBaudRate(const int fd, int* const outbaud);
+int linuxSetLowLatencyMode(const int fd, const bool enable);
 
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_LINUX_H_
 

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -332,6 +332,17 @@ void EIO_Set(uv_work_t* req) {
     bits |= TIOCM_DSR;
   }
 
+  #if defined(__linux__)
+  int err = linuxSetLowLatencyMode(data->fd, data->low_latency);
+  if (err == -1) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
+    return;
+  } else if(err == -2) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
+    return;
+  }
+  #endif
+
   int result = 0;
   if (data->brk) {
     result = ioctl(data->fd, TIOCSBRK, NULL);
@@ -358,6 +369,16 @@ void EIO_Get(uv_work_t* req) {
     snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
     return;
   }
+
+  data->low_latency = false;
+  #if defined(__linux__) && defined(ASYNC_LOW_LATENCY)
+  int latency_bits;
+  if (-1 == ioctl(data->fd, TIOCGSERIAL, &latency_bits)) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
+    return;
+  }
+  data->low_latency = latency_bits & ASYNC_LOW_LATENCY;
+  #endif
 
   data->cts = bits & TIOCM_CTS;
   data->dsr = bits & TIOCM_DSR;

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -333,7 +333,7 @@ void EIO_Set(uv_work_t* req) {
   }
 
   #if defined(__linux__)
-  int err = linuxSetLowLatencyMode(data->fd, data->low_latency);
+  int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
   if (err == -1) {
     snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
     return;
@@ -370,14 +370,14 @@ void EIO_Get(uv_work_t* req) {
     return;
   }
 
-  data->low_latency = false;
+  data->lowLatency = false;
   #if defined(__linux__) && defined(ASYNC_LOW_LATENCY)
   int latency_bits;
   if (-1 == ioctl(data->fd, TIOCGSERIAL, &latency_bits)) {
     snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
     return;
   }
-  data->low_latency = latency_bits & ASYNC_LOW_LATENCY;
+  data->lowLatency = latency_bits & ASYNC_LOW_LATENCY;
   #endif
 
   data->cts = bits & TIOCM_CTS;


### PR DESCRIPTION
Summary:
On Linux systems, the USB latency timer can be reduced from ~16ms to ~1ms when the `ASYNC_LOW_LATENCY` flag is set on the `serial_struct`. This commit enables enabling and disabling this mode.
This feature mimics using `setserial /dev/tty[...] low_latency` from the command line, and the commit to PySerial here: https://github.com/pyserial/pyserial/pull/290

Tests:
- Updated the automated tests to account for the new flag
- Compiled on both Linux and Mac OS platforms
- Verified automated tests still pass and tested against an Arduino Uno
- Tested manually enabling and disabling this flag