### PR TITLE
fix: disconnects should now work again on unix based systems

### DIFF
--- a/packages/bindings/lib/unix-read.js
+++ b/packages/bindings/lib/unix-read.js
@@ -46,7 +46,7 @@ const unixRead = async ({ binding, buffer, offset, length, fsReadAsync = readAsy
       err.errno === -1 // generic error
 
     if (disconnectError) {
-      err.canceled = true
+      err.disconnect = true
       logger('disconnecting', err)
     }
 

--- a/packages/bindings/lib/unix-read.test.js
+++ b/packages/bindings/lib/unix-read.test.js
@@ -95,10 +95,10 @@ describe('unixRead', () => {
     const err = await shouldReject(unixRead({ binding: mock, buffer: readBuffer, offset: 0, length: 8, fsReadAsync }))
     assert.isTrue(err.canceled)
   })
-  it('rejects a canceled error when fsread errors a disconnect error', async () => {
+  it('rejects a disconnected error when fsread errors a disconnect error', async () => {
     const readBuffer = Buffer.alloc(8, 0)
     const fsReadAsync = makeFsReadError('EBADF')
     const err = await shouldReject(unixRead({ binding: mock, buffer: readBuffer, offset: 0, length: 8, fsReadAsync }))
-    assert.isTrue(err.canceled)
+    assert.isTrue(err.disconnect)
   })
 })


### PR DESCRIPTION
This should fix #2043 thanks to @dunkmann00 for identifying the fix.