### PR TITLE
[fixes] while validating for offset, check for offset's value for NaN instead length

### DIFF
--- a/packages/binding-abstract/lib/index.js
+++ b/packages/binding-abstract/lib/index.js
@@ -85,8 +85,8 @@ The in progress reads must error when the port is closed with an error object th
       throw new TypeError('"buffer" is not a Buffer')
     }
 
-    if (typeof offset !== 'number' || isNaN(length)) {
-      throw new TypeError(`"offset" is not an integer got "${isNaN(length) ? 'NaN' : typeof offset}"`)
+    if (typeof offset !== 'number' || isNaN(offset)) {
+      throw new TypeError(`"offset" is not an integer got "${isNaN(offset) ? 'NaN' : typeof offset}"`)
     }
 
     if (typeof length !== 'number' || isNaN(length)) {


### PR DESCRIPTION
@reconbot,

in read method we have checked the type of `offset`, but while checking if the value `NaN` we have checked for the value of `length` instead of `offset`