### PR TITLE
Add a parser package for the Space Packet data format

### DIFF
--- a/packages/parser-spacepacket/.npmignore
+++ b/packages/parser-spacepacket/.npmignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.test.js
+CHANGELOG.md

--- a/packages/parser-spacepacket/README.md
+++ b/packages/parser-spacepacket/README.md
@@ -1,0 +1,1 @@
+See our api docs https://serialport.io/docs/api-parser-spacepacket

--- a/packages/parser-spacepacket/lib/index.js
+++ b/packages/parser-spacepacket/lib/index.js
@@ -1,0 +1,112 @@
+const { Transform } = require('stream')
+
+const { HEADER_LENGTH, convertHeaderBufferToObj } = require('./utils')
+
+/**
+ * A Transform stream that accepts a stream of octet data and converts it into an object
+ * representation of a CCSDS Space Packet. See https://public.ccsds.org/Pubs/133x0b2e1.pdf for a
+ * description of the Space Packet format.
+ *
+ * @extends Transform
+ */
+class SpacePacketParser extends Transform {
+  /**
+   *
+   * @param {Object} options Configuration options for the stream
+   * @param {Number} options.timeCodeFieldLength The length of the time code field within the data
+   * @param {Number} options.ancillaryDataFieldLength The length of the ancillary data field within the data
+   */
+  constructor(options = {}) {
+    super({ ...options, objectMode: true })
+    // Set the constants for this Space Packet Connection; these will help us parse incoming data
+    // fields:
+    this.timeCodeFieldLength = options.timeCodeFieldLength || 0
+    this.ancillaryDataFieldLength = options.ancillaryDataFieldLength || 0
+    this.dataSlice = this.timeCodeFieldLength + this.ancillaryDataFieldLength
+    // These are stateful based on the current packet being received:
+    this.dataBuffer = Buffer.alloc(0)
+    this.headerBuffer = Buffer.alloc(0)
+    this.dataLength = 0
+    this.expectingHeader = true
+  }
+
+  pushCompletedPacket() {
+    const completedPacket = { header: { ...this.header } }
+    const timeCode = Buffer.from(this.dataBuffer.slice(0, this.timeCodeFieldLength))
+    const ancillaryData = Buffer.from(this.dataBuffer.slice(this.timeCodeFieldLength, this.timeCodeFieldLength + this.ancillaryDataFieldLength))
+    const data = Buffer.from(this.dataBuffer.slice(this.dataSlice, this.dataLength))
+
+    if (timeCode.length > 0 || ancillaryData.length > 0) {
+      completedPacket.secondaryHeader = {}
+
+      if (timeCode.length) {
+        completedPacket.secondaryHeader.timeCode = timeCode.toString()
+      }
+
+      if (ancillaryData.length) {
+        completedPacket.secondaryHeader.ancillaryData = ancillaryData.toString()
+      }
+    }
+
+    completedPacket.data = data.toString()
+    this.push(completedPacket)
+
+    const nextChunk = Buffer.from(this.dataBuffer.slice(this.dataLength))
+
+    if (nextChunk.length >= HEADER_LENGTH) {
+      this.extractHeader(nextChunk)
+    } else {
+      this.headerBuffer = nextChunk
+      this.dataBuffer = Buffer.alloc(0)
+      this.expectingHeader = true
+      this.dataLength = 0
+      this.header = {}
+    }
+  }
+
+  extractHeader(chunk) {
+    const headerAsBuffer = Buffer.concat([this.headerBuffer, chunk])
+    const startOfDataBuffer = headerAsBuffer.slice(HEADER_LENGTH)
+
+    if (headerAsBuffer.length >= HEADER_LENGTH) {
+      this.header = convertHeaderBufferToObj(headerAsBuffer)
+      this.dataLength = this.header.dataLength
+      this.headerBuffer = Buffer.alloc(0)
+      this.expectingHeader = false
+    } else {
+      this.headerBuffer = headerAsBuffer
+    }
+
+    if (startOfDataBuffer.length > 0) {
+      this.dataBuffer = Buffer.from(startOfDataBuffer)
+
+      if (this.dataBuffer.length >= this.dataLength) {
+        this.pushCompletedPacket()
+      }
+    }
+  }
+
+  _transform(chunk, _, cb) {
+    if (this.expectingHeader) {
+      this.extractHeader(chunk)
+    } else {
+      this.dataBuffer = Buffer.concat([this.dataBuffer, chunk])
+
+      if (this.dataBuffer.length >= this.dataLength) {
+        this.pushCompletedPacket()
+      }
+    }
+
+    cb()
+  }
+
+  _flush(cb) {
+    const remaining = Buffer.concat([this.headerBuffer, this.dataBuffer])
+    const remainingArray = Array.from(remaining)
+
+    this.push(remainingArray)
+    cb()
+  }
+}
+
+module.exports = SpacePacketParser

--- a/packages/parser-spacepacket/lib/index.test.js
+++ b/packages/parser-spacepacket/lib/index.test.js
@@ -1,0 +1,169 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const SpacePacketParser = require('./index')
+
+const VERSION = '000'
+const TYPE = '0'
+const SECONDARY_HEADER = '1'
+const NO_SECONDARY_HEADER = '0'
+const API_ID = '10010010011'
+const UNSEGMENTED = '11'
+const COUNT = '00000000000001'
+const DATA_LENGTH = '0000000000000101'
+const DATA_LENGTH_WITH_2ARY_HEADER = '0000000000010001'
+
+const buildSixCharacterBasicSpacePacket = text => {
+  const data = text.slice(0, 6)
+  const baseArray = []
+  let headerAsString = `${VERSION}${TYPE}${NO_SECONDARY_HEADER}${API_ID}${UNSEGMENTED}${COUNT}${DATA_LENGTH}`
+
+  while (headerAsString.length) {
+    const next = headerAsString.slice(0, 8)
+
+    baseArray.push(parseInt(next, 2))
+    headerAsString = headerAsString.slice(8)
+  }
+
+  return {
+    buffer: Buffer.concat([Buffer.from(baseArray), Buffer.from(data)]),
+    expected: {
+      header: {
+        versionNumber: 1,
+        identification: {
+          apid: parseInt(API_ID, 2),
+          secondaryHeader: 0,
+          type: 0,
+        },
+        sequenceControl: {
+          packetName: parseInt(COUNT, 2),
+          sequenceFlags: 3,
+        },
+        dataLength: 6,
+      },
+      data,
+    },
+  }
+}
+
+const buildSixCharacterBasicSpacePacketWithSecondaryHeaderLength6 = text => {
+  const data = text.slice(0, 6)
+  const baseArray = []
+  const TIMECO = 'TIMECO'
+  const ANCILL = 'ANCILL'
+  const dataBuffer = Buffer.concat([Buffer.from(TIMECO), Buffer.from(ANCILL), Buffer.from(data)])
+  let headerAsString = `${VERSION}${TYPE}${SECONDARY_HEADER}${API_ID}${UNSEGMENTED}${COUNT}${DATA_LENGTH_WITH_2ARY_HEADER}`
+
+  while (headerAsString.length) {
+    const next = headerAsString.slice(0, 8)
+
+    baseArray.push(parseInt(next, 2))
+    headerAsString = headerAsString.slice(8)
+  }
+
+  return {
+    buffer: Buffer.concat([Buffer.from(baseArray), dataBuffer]),
+    expected: {
+      header: {
+        versionNumber: 1,
+        identification: {
+          apid: parseInt(API_ID, 2),
+          secondaryHeader: 1,
+          type: 0,
+        },
+        sequenceControl: {
+          packetName: parseInt(COUNT, 2),
+          sequenceFlags: 3,
+        },
+        dataLength: 18,
+      },
+      secondaryHeader: {
+        timeCode: TIMECO,
+        ancillaryData: ANCILL,
+      },
+      data,
+    },
+  }
+}
+
+describe('SpacePacketParser', () => {
+  let test
+
+  beforeEach(() => {
+    test = new SpacePacketParser()
+  })
+
+  it('handles a complete space packet buffer sent at once', () => {
+    const { buffer, expected } = buildSixCharacterBasicSpacePacket('123456')
+
+    test.on('data', data => {
+      expect(data).to.deep.equal(expected)
+    })
+
+    test.write(buffer)
+  })
+
+  it('flushes a partial packet if end is called', () => {
+    const { buffer } = buildSixCharacterBasicSpacePacket('things')
+
+    test.on('data', data => {
+      expect(data.length).to.equal(4)
+    })
+
+    test.write(buffer.slice(0, 4))
+
+    test.end()
+  })
+
+  it('handles receiving two space packets at the same time', () => {
+    const { buffer, expected } = buildSixCharacterBasicSpacePacket('first1')
+    const { buffer: buff2, expected: expect2 } = buildSixCharacterBasicSpacePacket('second')
+    const dataCallbackSpy = sinon.stub()
+
+    test.on('data', dataCallbackSpy)
+    test.write(Buffer.concat([buffer, buff2]))
+
+    expect(dataCallbackSpy.callCount).to.equal(2)
+    sinon.assert.calledWith(dataCallbackSpy.getCall(0), expected)
+    sinon.assert.calledWith(dataCallbackSpy.getCall(1), expect2)
+  })
+
+  it('handles receiving parts of a space packet in chunks', () => {
+    const { buffer, expected } = buildSixCharacterBasicSpacePacket('partsy')
+    const dataCallbackSpy = sinon.stub()
+
+    test.on('data', dataCallbackSpy)
+
+    for (let i = 0; i < buffer.length; i++) {
+      test.write(Buffer.from([buffer[i]]))
+    }
+
+    expect(dataCallbackSpy.callCount).to.equal(1)
+    sinon.assert.calledWith(dataCallbackSpy, expected)
+  })
+
+  it('handles receiving a complete plus a partial packet at once', () => {
+    const { buffer, expected } = buildSixCharacterBasicSpacePacket('part_1')
+    const { buffer: buff2 } = buildSixCharacterBasicSpacePacket('part_2')
+    const onePoint5ishPackets = Buffer.concat([buffer, buff2]).slice(0, 16)
+    const dataCallbackSpy = sinon.stub()
+
+    test.on('data', dataCallbackSpy)
+
+    test.write(onePoint5ishPackets)
+
+    expect(dataCallbackSpy.callCount).to.equal(1)
+    sinon.assert.calledWith(dataCallbackSpy, expected)
+  })
+
+  it('includes timeCode and ancillaryData fields in a secondary header object', () => {
+    const test2 = new SpacePacketParser({ timeCodeFieldLength: 6, ancillaryDataFieldLength: 6 })
+    const { buffer, expected } = buildSixCharacterBasicSpacePacketWithSecondaryHeaderLength6('123456')
+
+    test2.on('data', data => {
+      expect(data).to.deep.equal(expected)
+    })
+
+    test2.write(buffer)
+  })
+})

--- a/packages/parser-spacepacket/lib/utils.js
+++ b/packages/parser-spacepacket/lib/utils.js
@@ -21,22 +21,15 @@ const toOctetStr = num => {
  * @param {Buffer} buf The buffer containing the Space Packet Header Data
  */
 const convertHeaderBufferToObj = buf => {
-  const [byte0, byte1, byte2, byte3, byte4, byte5] = [...buf.slice(0, HEADER_LENGTH)]
-  const isVersion1 = toOctetStr(byte0).indexOf('000') === 0
+  const headerStr = Array.from(buf.slice(0, HEADER_LENGTH)).reduce((accum, curr) => `${accum}${toOctetStr(curr)}`, '')
+  const isVersion1 = headerStr.slice(0, 3) === '000'
   const versionNumber = isVersion1 ? 1 : 'UNKNOWN_VERSION'
-  const type = byte0 >>> 4
-  const secondaryHeader = (byte0 >>> 3) % 2
-  const zeroAndOneAsBinString = [byte0, byte1].reduce((accum, curr) => `${accum}${toOctetStr(curr)}`, '')
-  const apidAsBinString = zeroAndOneAsBinString.slice(5)
-  const apid = parseInt(apidAsBinString, 2)
-  const byte2AsBinString = toOctetStr(byte2)
-  const sequenceFlags = parseInt(byte2AsBinString.slice(0, 2), 2)
-  const packetNameAsBinString = `${byte2AsBinString}${toOctetStr(byte3)}`.slice(2)
-  const packetName = parseInt(packetNameAsBinString, 2)
-  const packetLengthAsBinString = [byte4, byte5].reduce((accum, curr) => {
-    return `${accum}${toOctetStr(curr)}`
-  }, '')
-  const dataLength = parseInt(packetLengthAsBinString, 2) + 1
+  const type = Number(headerStr[3])
+  const secondaryHeader = Number(headerStr[4])
+  const apid = parseInt(headerStr.slice(5, 16), 2)
+  const sequenceFlags = parseInt(headerStr.slice(16, 18), 2)
+  const packetName = parseInt(headerStr.slice(18, 32), 2)
+  const dataLength = parseInt(headerStr.slice(-16), 2) + 1
 
   return {
     versionNumber,

--- a/packages/parser-spacepacket/lib/utils.js
+++ b/packages/parser-spacepacket/lib/utils.js
@@ -1,0 +1,60 @@
+const HEADER_LENGTH = 6
+
+/**
+ * For numbers less than 255, will ensure that their string representation is at least 8
+ * characters long.
+ * @param {Number} num Any number
+ */
+const toOctetStr = num => {
+  let str = Number(num).toString(2)
+
+  while (str.length < 8) {
+    str = `0${str}`
+  }
+
+  return str
+}
+
+/**
+ * Converts a Buffer of any length to an Object representation of a Space Packet header, provided
+ * the received data is in the correct format.
+ * @param {Buffer} buf The buffer containing the Space Packet Header Data
+ */
+const convertHeaderBufferToObj = buf => {
+  const [byte0, byte1, byte2, byte3, byte4, byte5] = [...buf.slice(0, HEADER_LENGTH)]
+  const isVersion1 = toOctetStr(byte0).indexOf('000') === 0
+  const versionNumber = isVersion1 ? 1 : 'UNKNOWN_VERSION'
+  const type = byte0 >>> 4
+  const secondaryHeader = (byte0 >>> 3) % 2
+  const zeroAndOneAsBinString = [byte0, byte1].reduce((accum, curr) => `${accum}${toOctetStr(curr)}`, '')
+  const apidAsBinString = zeroAndOneAsBinString.slice(5)
+  const apid = parseInt(apidAsBinString, 2)
+  const byte2AsBinString = toOctetStr(byte2)
+  const sequenceFlags = parseInt(byte2AsBinString.slice(0, 2), 2)
+  const packetNameAsBinString = `${byte2AsBinString}${toOctetStr(byte3)}`.slice(2)
+  const packetName = parseInt(packetNameAsBinString, 2)
+  const packetLengthAsBinString = [byte4, byte5].reduce((accum, curr) => {
+    return `${accum}${toOctetStr(curr)}`
+  }, '')
+  const dataLength = parseInt(packetLengthAsBinString, 2) + 1
+
+  return {
+    versionNumber,
+    identification: {
+      apid,
+      secondaryHeader,
+      type,
+    },
+    sequenceControl: {
+      packetName,
+      sequenceFlags,
+    },
+    dataLength,
+  }
+}
+
+module.exports = {
+  HEADER_LENGTH,
+  toOctetStr,
+  convertHeaderBufferToObj,
+}

--- a/packages/parser-spacepacket/package.json
+++ b/packages/parser-spacepacket/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@serialport/parser-spacepacket",
+  "main": "lib",
+  "version": "9.0.1",
+  "engines": {
+    "node": ">=8.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/serialport/node-serialport.git"
+  }
+}


### PR DESCRIPTION
A parser for the [CCSDS Space Packet data format](https://public.ccsds.org/Pubs/133x0b2e1.pdf).

Receives incoming data as a Buffer; parses the header and uses the dataLength property found therein to determine when the whole packet has been received. Emits an object representation of the entire packet, including primary and secondary headers, once it's been completely received.

Docs are included in a PR to the /website repo.