### PR TITLE
Explicitly specify node-abi version in top-level package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8935,9 +8935,9 @@
       }
     },
     "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "lerna": "^3.22.1",
     "mocha": "^8.2.1",
+    "node-abi": "^2.19.3",
     "nyc": "^15.1.0",
     "plop": "^2.7.4",
     "prebuild": "^10.0.1",

--- a/packages/bindings/package-lock.json
+++ b/packages/bindings/package-lock.json
@@ -4,37 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
-      "requires": {
-        "debug": "^4.1.1"
-      }
-    },
-    "@serialport/binding-mock": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.2.tgz",
-      "integrity": "sha512-HfrvJ/LXULHk8w63CGxwDNiDidFgDX8BnadY+cgVS6yHMHikbhLCLjCmUKsKBWaGKRqOznl0w+iUl7TMi1lkXQ==",
-      "dev": true,
-      "requires": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "debug": "^4.1.1"
-      }
-    },
-    "@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ=="
-    },
-    "@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
-      "requires": {
-        "@serialport/parser-delimiter": "^9.0.1"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",


### PR DESCRIPTION
[As was discovered](https://github.com/serialport/node-serialport/issues/2156#issuecomment-738986150) by @choppsta, the node-abi also needs to be specified in the top-level package.json. This PR will hopefully accomplish what #2183 was meant to accomplish.

As a side note, I believe this wouldn't have been an issue if this library was using lerna's hoisting option. Enabling that is something that should probably be considered.

If this works, #2140, #2156, and #2159 should be closed.