### PR TITLE
rectifies datatype of variable holding Serial.read

### DIFF
--- a/packages/serialport/test-arduino/arduinoEcho/arduinoEcho.ino
+++ b/packages/serialport/test-arduino/arduinoEcho/arduinoEcho.ino
@@ -9,7 +9,7 @@ void setup() {
 
 void loop() {
   while (Serial.available()) {
-    int byte = Serial.read();
-    Serial.write(byte);
+    uint8_t oneByteData = Serial.read();
+    Serial.write(oneByteData);
   }
 }


### PR DESCRIPTION
int on Arduino's flavor of C++ is 2-byte (or more), see https://www.arduino.cc/reference/en/language/variables/data-types/int/

The previous code worked fortunately as Serial.write read only lower byte and since max incoming value is <= 126 overflow errors didn't happen.

Also, byte is a reserved keyword in Arduino C++