### PR TITLE
chore: cleanup package.json's

### DIFF
--- a/.generators/package.json
+++ b/.generators/package.json
@@ -6,7 +6,7 @@
     "debug": "^4.3.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -15,5 +15,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,10 @@
         "sinon": "^9.2.4"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Node.js packages to access serial ports, process data from them and speak many protocols",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -25,13 +25,6 @@
     "type": "git",
     "url": "git://github.com/node-serialport/node-serialport.git"
   },
-  "maintainers": [
-    {
-      "name": "Francis Gulotta",
-      "email": "wizard@roborooter.com",
-      "url": "https://www.roborooter.com"
-    }
-  ],
   "devDependencies": {
     "cc": "^3.0.1",
     "chai": "^4.3.0",
@@ -53,5 +46,6 @@
     "prettier": "^2.2.1",
     "proxyquire": "^2.1.3",
     "sinon": "^9.2.4"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/binding-abstract/package.json
+++ b/packages/binding-abstract/package.json
@@ -9,7 +9,7 @@
     "debug": "^4.3.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -18,5 +18,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/binding-mock/package.json
+++ b/packages/binding-mock/package.json
@@ -10,7 +10,7 @@
     "debug": "^4.3.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -19,5 +19,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -18,7 +18,7 @@
     "node-abi": "^2.19.3"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "install": "prebuild-install --tag-prefix @serialport/bindings@ || node-gyp rebuild",
@@ -45,5 +45,6 @@
       "src/*.h"
     ],
     "linelength": "120"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -10,7 +10,7 @@
     "commander": "^7.1.0"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -19,5 +19,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-byte-length/package.json
+++ b/packages/parser-byte-length/package.json
@@ -3,7 +3,7 @@
   "version": "9.0.1",
   "main": "lib",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-cctalk/package.json
+++ b/packages/parser-cctalk/package.json
@@ -3,7 +3,7 @@
   "version": "9.0.1",
   "main": "lib",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-delimiter/package.json
+++ b/packages/parser-delimiter/package.json
@@ -3,7 +3,7 @@
   "main": "lib",
   "version": "9.0.1",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-inter-byte-timeout/package.json
+++ b/packages/parser-inter-byte-timeout/package.json
@@ -3,7 +3,7 @@
   "version": "9.0.1",
   "main": "lib",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-readline/package.json
+++ b/packages/parser-readline/package.json
@@ -6,7 +6,7 @@
     "@serialport/parser-delimiter": "^9.0.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -15,5 +15,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-ready/package.json
+++ b/packages/parser-ready/package.json
@@ -3,7 +3,7 @@
   "main": "lib",
   "version": "9.0.1",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-regex/package.json
+++ b/packages/parser-regex/package.json
@@ -3,7 +3,7 @@
   "main": "lib",
   "version": "9.0.1",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-slip-encoder/package.json
+++ b/packages/parser-slip-encoder/package.json
@@ -3,7 +3,7 @@
   "main": "lib",
   "version": "9.0.1",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/parser-spacepacket/package.json
+++ b/packages/parser-spacepacket/package.json
@@ -3,7 +3,7 @@
   "main": "lib",
   "version": "9.0.5",
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -10,7 +10,7 @@
     "serialport": "^9.0.6"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -19,5 +19,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/serialport/package.json
+++ b/packages/serialport/package.json
@@ -58,11 +58,9 @@
     "debug": "^4.3.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
-  "scripts": {
-    "postinstall": "node thank-you.js"
-  },
+  "funding": "https://opencollective.com/serialport/donate",
   "preferUnplugged": false
 }

--- a/packages/serialport/thank-you.js
+++ b/packages/serialport/thank-you.js
@@ -1,3 +1,0 @@
-const message =
-  '\u001b[96m\u001b[1mThank you for using serialport!\u001b[96m\u001b[1m\n\u001b[0m\u001b[96mIf you rely on this package, please consider supporting our open collective:\u001b[22m\u001b[39m\n> \u001b[94mhttps://opencollective.com/serialport/donate\u001b[0m\n\n'
-console.log(message)

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -9,7 +9,7 @@
     "@serialport/binding-mock": "^9.0.2"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -18,5 +18,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -12,7 +12,7 @@
     "enquirer": "^2.3.5"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -21,5 +21,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
-  }
+  },
+  "funding": "https://opencollective.com/serialport/donate"
 }


### PR DESCRIPTION
- Remove the post install in serialport and switch to the funding property
- Update the engines field as we don't support node 8 anymore, only node >= 10.0.0