### PR TITLE
fix x32 build

### DIFF
--- a/packages/bindings/binding.gyp
+++ b/packages/bindings/binding.gyp
@@ -1,7 +1,7 @@
 {
   'variables': {
     'v8_enable_pointer_compression%': 0,
-	  'v8_enable_31bit_smis_on_64bit_arch%': 0,
+    'v8_enable_31bit_smis_on_64bit_arch%': 0,
   },
   'targets': [{
     'target_name': 'bindings',

--- a/packages/bindings/binding.gyp
+++ b/packages/bindings/binding.gyp
@@ -1,4 +1,8 @@
 {
+  'variables': {
+    'v8_enable_pointer_compression%': 0,
+	  'v8_enable_31bit_smis_on_64bit_arch%': 0,
+  },
   'targets': [{
     'target_name': 'bindings',
     'sources': [


### PR DESCRIPTION
I tried to build the project on x86, nothing worked, I get an error 
```bash
gyp: name 'v8_enable_pointer_compression' is not defined while evaluating condition 'v8_enable_pointer_compression == 1' in binding.gyp while trying to load bin"
ding.gyp
```
This error only happens on the old version of the node.
if v8_enable_pointer_compression=1 i see new error
```bash
"C:\test\node_modules\@serialport\bindings\build\binding.sln" (default target)
(1) ->"C:\test\node_modules\@serialport\bindings\build\bindings.vcxproj" (default tar get) (2) ->
(ClCompile target) ->  c:\users\ieuser\appdata\local\temp\prebuild\node\14.0.0\include\node\v8-internal.h(102): error C2338: Pointer compression can be enabled only for 64-bit architectures (compiling source file ..\src\serialport.cpp) [C:\test\node_modules\@serialport\bindings\build\bindings.vcxproj] 
 c:\users\ieuser\appdata\local\temp\prebuild\node\14.0.0\include\node\v8-internal.h(102): error C2338: Pointer compression can be enabled only for 64-bit architectures (compiling source file ..\src\serialport_win.cpp) [C:\test\node_modules\@serialport\bindings\build\bindings.vcxproj]
```

a little information
https://github.com/nodejs/node/blob/master/common.gypi

These parameters appeared recently and were not available before, perhaps they need to be enabled only on not x64

after adding this parameters, the bild was completed!