### PR TITLE
fix: electron 11 prebuilds broken

### DIFF
--- a/packages/bindings/binding.gyp
+++ b/packages/bindings/binding.gyp
@@ -10,6 +10,7 @@
     'conditions': [
       ['OS=="win"',
         {
+          'defines': ['CHECK_NODE_MODULE_VERSION'],
           'sources': [
             'src/serialport_win.cpp'
           ],

--- a/packages/bindings/src/serialport.h
+++ b/packages/bindings/src/serialport.h
@@ -1,5 +1,12 @@
 #ifndef PACKAGES_SERIALPORT_SRC_SERIALPORT_H_
 #define PACKAGES_SERIALPORT_SRC_SERIALPORT_H_
+
+// Workaround for electron 11 abi issue https://github.com/serialport/node-serialport/issues/2191
+#include <node_version.h>
+#if CHECK_NODE_MODULE_VERSION && NODE_MODULE_VERSION == 85
+#define V8_REVERSE_JSARGS
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #2191 

A temporary fix until fixed upstream https://github.com/lgeiger/node-abi/issues/103 or https://github.com/prebuild/prebuild/issues/275

As explained in my comment https://github.com/serialport/node-serialport/issues/2191#issuecomment-819149005, electron v11.0.0-beta.12 started to define the variable `V8_REVERSE_JSARGS`. But as prebuild/node-abi use v11.0.0-beta.11 for producing the prebuilds, this resulted in binaries which were broken.

This is the simplest way I could find to do this while keeping it scoped to just electron 11. I couldn't find a way to check `NODE_MODULE_VERSION` in binding.gyp, so I had to do it in serialport.h instead.
It is limited to windows as that appears to be the only platform that is broken, and without testing I don't know what the impact would be on other platforms

