### PR TITLE
Linux low latency fix (allow set without changing low latency mode)

### DIFF
--- a/packages/bindings/src/serialport_linux.cpp
+++ b/packages/bindings/src/serialport_linux.cpp
@@ -43,6 +43,8 @@ int linuxSetLowLatencyMode(const int fd, const bool enable) {
   if (ioctl(fd, TIOCGSERIAL, &ss)) {
     return -1;
   }
+  
+  int oldFlags = ss.flags;
 
   if (enable) {
     ss.flags |= ASYNC_LOW_LATENCY;
@@ -50,9 +52,24 @@ int linuxSetLowLatencyMode(const int fd, const bool enable) {
     ss.flags &= ~ASYNC_LOW_LATENCY;
   }
 
-  if (ioctl(fd, TIOCSSERIAL, &ss)) {
-    return -2;
+  if (oldFlags != ss.flags)
+  {
+    if (ioctl(fd, TIOCSSERIAL, &ss)) {
+      return -2;
+    }
   }
+
+  return 0;
+}
+
+int linuxGetLowLatencyMode(const int fd, bool* const enabled) {
+  struct serial_struct ss;
+
+  if (ioctl(fd, TIOCGSERIAL, &ss)) {
+    return -1;
+  }
+
+  *enabled = ss.flags & ASYNC_LOW_LATENCY;
 
   return 0;
 }

--- a/packages/bindings/src/serialport_linux.cpp
+++ b/packages/bindings/src/serialport_linux.cpp
@@ -17,7 +17,7 @@ int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate) {
     t.c_cflag |= BOTHER;
     t.c_ospeed = t.c_ispeed = baudrate;
 
-    if (ioctl(fd, TCSETS2, &t)) {
+    if (ioctl(fd, TCSETS2, &t) < 0) {
       return -2;
     }
 
@@ -43,22 +43,19 @@ int linuxSetLowLatencyMode(const int fd, const bool enable) {
   if (ioctl(fd, TIOCGSERIAL, &ss)) {
     return -1;
   }
-  
-  int oldFlags = ss.flags;
 
-  if (enable) {
-    ss.flags |= ASYNC_LOW_LATENCY;
-  } else {
-    ss.flags &= ~ASYNC_LOW_LATENCY;
-  }
+  if (ss.flags & ASYNC_LOW_LATENCY != enable) {
+    
+    if (enable) {
+      ss.flags |= ASYNC_LOW_LATENCY;
+    } else {
+      ss.flags &= ~ASYNC_LOW_LATENCY;
+    }
 
-  if (oldFlags != ss.flags)
-  {
-    if (ioctl(fd, TIOCSSERIAL, &ss)) {
+    if (ioctl(fd, TIOCSSERIAL, &ss) < 0) {
       return -2;
     }
   }
-
   return 0;
 }
 

--- a/packages/bindings/src/serialport_linux.h
+++ b/packages/bindings/src/serialport_linux.h
@@ -4,6 +4,7 @@
 int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate);
 int linuxGetSystemBaudRate(const int fd, int* const outbaud);
 int linuxSetLowLatencyMode(const int fd, const bool enable);
+int linuxGetLowLatencyMode(const int fd, bool* const enabled);
 
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_LINUX_H_
 

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -333,13 +333,15 @@ void EIO_Set(uv_work_t* req) {
   }
 
   #if defined(__linux__)
-  int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
-  if (err == -1) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
-    return;
-  } else if(err == -2) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
-    return;
+  if (data->lowLatency) {
+    int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
+    if (err == -1) {
+      snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
+      return;
+    } else if(err == -2) {
+      snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
+      return;
+    }
   }
   #endif
 

--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -332,19 +332,6 @@ void EIO_Set(uv_work_t* req) {
     bits |= TIOCM_DSR;
   }
 
-  #if defined(__linux__)
-  if (data->lowLatency) {
-    int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
-    if (err == -1) {
-      snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
-      return;
-    } else if(err == -2) {
-      snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
-      return;
-    }
-  }
-  #endif
-
   int result = 0;
   if (data->brk) {
     result = ioctl(data->fd, TIOCSBRK, NULL);
@@ -361,6 +348,17 @@ void EIO_Set(uv_work_t* req) {
     snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set", strerror(errno));
     return;
   }
+
+  #if defined(__linux__)
+  int err = linuxSetLowLatencyMode(data->fd, data->lowLatency);
+  if (err == -1) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get low latency", strerror(errno));
+    return;
+  } else if(err == -2) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot set low latency", strerror(errno));
+    return;
+}
+  #endif
 }
 
 void EIO_Get(uv_work_t* req) {
@@ -372,19 +370,20 @@ void EIO_Get(uv_work_t* req) {
     return;
   }
 
-  data->lowLatency = false;
-  #if defined(__linux__) && defined(ASYNC_LOW_LATENCY)
-  int latency_bits;
-  if (-1 == ioctl(data->fd, TIOCGSERIAL, &latency_bits)) {
-    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get", strerror(errno));
-    return;
-  }
-  data->lowLatency = latency_bits & ASYNC_LOW_LATENCY;
-  #endif
-
   data->cts = bits & TIOCM_CTS;
   data->dsr = bits & TIOCM_DSR;
   data->dcd = bits & TIOCM_CD;
+
+  #if defined(__linux__) && defined(ASYNC_LOW_LATENCY)
+  bool lowlatency = false;
+  if (-1 == linuxGetLowLatencyMode(data->fd, &lowlatency)) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error: %s, cannot get low latency", strerror(errno));
+    return;
+  }
+  data->lowLatency = lowlatency;
+  #else
+  data->lowLatency = false;
+  #endif
 }
 
 void EIO_GetBaudRate(uv_work_t* req) {


### PR DESCRIPTION
Only set low Latency mode if lowLatency is defined

Proposed fix to address https://github.com/serialport/node-serialport/issues/2240