### PR TITLE
feat: Pin version numbers for all monorepo packages

### DIFF
--- a/packages/list/package-lock.json
+++ b/packages/list/package-lock.json
@@ -6,64 +6,79 @@
   "packages": {
     "": {
       "name": "@serialport/list",
-      "version": "9.0.4",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
-        "@serialport/bindings": "^9.0.4",
+        "@serialport/bindings": "9.1.0",
         "commander": "^7.1.0"
       },
       "bin": {
         "serialport-list": "lib/index.js"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+      "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/bindings": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-      "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
+      "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "@serialport/parser-readline": "^9.0.1",
+        "@serialport/binding-abstract": "^9.0.7",
+        "@serialport/parser-readline": "^9.0.7",
         "bindings": "^1.5.0",
         "debug": "^4.3.1",
         "nan": "^2.14.2",
-        "prebuild-install": "^6.0.0"
+        "prebuild-install": "^6.0.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
       "dependencies": {
-        "@serialport/parser-delimiter": "^9.0.1"
+        "@serialport/parser-delimiter": "^9.0.7"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/ansi-regex": {
@@ -661,37 +676,37 @@
   },
   "dependencies": {
     "@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+      "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       }
     },
     "@serialport/bindings": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-      "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
+      "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
       "requires": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "@serialport/parser-readline": "^9.0.1",
+        "@serialport/binding-abstract": "^9.0.7",
+        "@serialport/parser-readline": "^9.0.7",
         "bindings": "^1.5.0",
         "debug": "^4.3.1",
         "nan": "^2.14.2",
-        "prebuild-install": "^6.0.0"
+        "prebuild-install": "^6.0.1"
       }
     },
     "@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ=="
     },
     "@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
       "requires": {
-        "@serialport/parser-delimiter": "^9.0.1"
+        "@serialport/parser-delimiter": "^9.0.7"
       }
     },
     "ansi-regex": {

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -6,7 +6,7 @@
     "serialport-list": "./lib/index.js"
   },
   "dependencies": {
-    "@serialport/bindings": "^9.1.0",
+    "@serialport/bindings": "9.1.0",
     "commander": "^7.1.0"
   },
   "engines": {

--- a/packages/serialport/package-lock.json
+++ b/packages/serialport/package-lock.json
@@ -5,134 +5,169 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "9.0.6",
-      "hasInstallScript": true,
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
-        "@serialport/binding-mock": "^9.0.2",
-        "@serialport/bindings": "^9.0.4",
-        "@serialport/parser-byte-length": "^9.0.1",
-        "@serialport/parser-cctalk": "^9.0.1",
-        "@serialport/parser-delimiter": "^9.0.1",
-        "@serialport/parser-inter-byte-timeout": "^9.0.1",
-        "@serialport/parser-readline": "^9.0.1",
-        "@serialport/parser-ready": "^9.0.1",
-        "@serialport/parser-regex": "^9.0.1",
-        "@serialport/stream": "^9.0.2",
+        "@serialport/binding-mock": "9.0.7",
+        "@serialport/bindings": "9.1.0",
+        "@serialport/parser-byte-length": "9.0.7",
+        "@serialport/parser-cctalk": "9.0.7",
+        "@serialport/parser-delimiter": "9.0.7",
+        "@serialport/parser-inter-byte-timeout": "9.0.7",
+        "@serialport/parser-readline": "9.0.7",
+        "@serialport/parser-ready": "9.0.7",
+        "@serialport/parser-regex": "9.0.7",
+        "@serialport/stream": "9.0.7",
         "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+      "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/binding-mock": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.2.tgz",
-      "integrity": "sha512-HfrvJ/LXULHk8w63CGxwDNiDidFgDX8BnadY+cgVS6yHMHikbhLCLjCmUKsKBWaGKRqOznl0w+iUl7TMi1lkXQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.7.tgz",
+      "integrity": "sha512-aR8H+htZwwZZkVb1MdbnNvGWw8eXVRqQ2qPhkbKyx0N/LY5aVIgCgT98Kt1YylLsG7SzNG+Jbhd4wzwEuPVT5Q==",
       "dependencies": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "debug": "^4.1.1"
+        "@serialport/binding-abstract": "^9.0.7",
+        "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/bindings": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-      "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
+      "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "@serialport/parser-readline": "^9.0.1",
+        "@serialport/binding-abstract": "^9.0.7",
+        "@serialport/parser-readline": "^9.0.7",
         "bindings": "^1.5.0",
         "debug": "^4.3.1",
         "nan": "^2.14.2",
-        "prebuild-install": "^6.0.0"
+        "prebuild-install": "^6.0.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-byte-length": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.1.tgz",
-      "integrity": "sha512-1Ikv4lgCNw8OMf35yCpgzjHwkpgBEkhBuXFXIdWZk+ixaHFLlAtp03QxGPZBmzHMK58WDmEQoBHC1V5BkkAKSQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
+      "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-cctalk": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.1.tgz",
-      "integrity": "sha512-GtMda2DeJ+23bNqOc79JYV06dax2n3FLLFM3zA7nfReCOi98QbuDj4TUbFESMOnp4DB0oMO0GYHCR9gHOedTkg==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
+      "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-inter-byte-timeout": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.1.tgz",
-      "integrity": "sha512-lFflcUflcP5SF4vLIixAKs1xUI/wfOzCv1Xq78VbPOBlIjZ6ny9lQ6g7cMPR/sB/M1BHwGcdX7CEr90pe3kkog==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
+      "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
       "dependencies": {
-        "@serialport/parser-delimiter": "^9.0.1"
+        "@serialport/parser-delimiter": "^9.0.7"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-ready": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.1.tgz",
-      "integrity": "sha512-lgzGkVJaaV1rJVx26WwI2UKyPxc0vu1rsOeldzA3VVbF+ABrblUQA06+cRPpT6k96GY+X4+1fB1rWuPpt8HbgQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
+      "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-regex": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.1.tgz",
-      "integrity": "sha512-BHTV+Lkl+J8hSecFtDRENaR4fgA6tw44J+dmA1vEKEyum0iDN4bihbu8yvztYyo4PhBGUKDfm/PnD5EkJm0dPA==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
+      "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/stream": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.2.tgz",
-      "integrity": "sha512-0RkVe+gvwZu/PPfbb7ExQ+euGoCTGKD/B8TQ5fuhe+eKk1sh73RwjKmu9gp6veSNqx9Zljnh1dF6mhdEKWZpSA==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
+      "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/ansi-regex": {
@@ -722,79 +757,79 @@
   },
   "dependencies": {
     "@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+      "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       }
     },
     "@serialport/binding-mock": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.2.tgz",
-      "integrity": "sha512-HfrvJ/LXULHk8w63CGxwDNiDidFgDX8BnadY+cgVS6yHMHikbhLCLjCmUKsKBWaGKRqOznl0w+iUl7TMi1lkXQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.7.tgz",
+      "integrity": "sha512-aR8H+htZwwZZkVb1MdbnNvGWw8eXVRqQ2qPhkbKyx0N/LY5aVIgCgT98Kt1YylLsG7SzNG+Jbhd4wzwEuPVT5Q==",
       "requires": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "debug": "^4.1.1"
+        "@serialport/binding-abstract": "^9.0.7",
+        "debug": "^4.3.1"
       }
     },
     "@serialport/bindings": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-      "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
+      "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
       "requires": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "@serialport/parser-readline": "^9.0.1",
+        "@serialport/binding-abstract": "^9.0.7",
+        "@serialport/parser-readline": "^9.0.7",
         "bindings": "^1.5.0",
         "debug": "^4.3.1",
         "nan": "^2.14.2",
-        "prebuild-install": "^6.0.0"
+        "prebuild-install": "^6.0.1"
       }
     },
     "@serialport/parser-byte-length": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.1.tgz",
-      "integrity": "sha512-1Ikv4lgCNw8OMf35yCpgzjHwkpgBEkhBuXFXIdWZk+ixaHFLlAtp03QxGPZBmzHMK58WDmEQoBHC1V5BkkAKSQ=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
+      "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA=="
     },
     "@serialport/parser-cctalk": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.1.tgz",
-      "integrity": "sha512-GtMda2DeJ+23bNqOc79JYV06dax2n3FLLFM3zA7nfReCOi98QbuDj4TUbFESMOnp4DB0oMO0GYHCR9gHOedTkg=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
+      "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q=="
     },
     "@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ=="
     },
     "@serialport/parser-inter-byte-timeout": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.1.tgz",
-      "integrity": "sha512-lFflcUflcP5SF4vLIixAKs1xUI/wfOzCv1Xq78VbPOBlIjZ6ny9lQ6g7cMPR/sB/M1BHwGcdX7CEr90pe3kkog=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
+      "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA=="
     },
     "@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
       "requires": {
-        "@serialport/parser-delimiter": "^9.0.1"
+        "@serialport/parser-delimiter": "^9.0.7"
       }
     },
     "@serialport/parser-ready": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.1.tgz",
-      "integrity": "sha512-lgzGkVJaaV1rJVx26WwI2UKyPxc0vu1rsOeldzA3VVbF+ABrblUQA06+cRPpT6k96GY+X4+1fB1rWuPpt8HbgQ=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
+      "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg=="
     },
     "@serialport/parser-regex": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.1.tgz",
-      "integrity": "sha512-BHTV+Lkl+J8hSecFtDRENaR4fgA6tw44J+dmA1vEKEyum0iDN4bihbu8yvztYyo4PhBGUKDfm/PnD5EkJm0dPA=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
+      "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw=="
     },
     "@serialport/stream": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.2.tgz",
-      "integrity": "sha512-0RkVe+gvwZu/PPfbb7ExQ+euGoCTGKD/B8TQ5fuhe+eKk1sh73RwjKmu9gp6veSNqx9Zljnh1dF6mhdEKWZpSA==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
+      "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       }
     },
     "ansi-regex": {

--- a/packages/serialport/package.json
+++ b/packages/serialport/package.json
@@ -45,16 +45,16 @@
     }
   ],
   "dependencies": {
-    "@serialport/binding-mock": "^9.0.7",
-    "@serialport/bindings": "^9.1.0",
-    "@serialport/parser-byte-length": "^9.0.7",
-    "@serialport/parser-cctalk": "^9.0.7",
-    "@serialport/parser-delimiter": "^9.0.7",
-    "@serialport/parser-inter-byte-timeout": "^9.0.7",
-    "@serialport/parser-readline": "^9.0.7",
-    "@serialport/parser-ready": "^9.0.7",
-    "@serialport/parser-regex": "^9.0.7",
-    "@serialport/stream": "^9.0.7",
+    "@serialport/binding-mock": "9.0.7",
+    "@serialport/bindings": "9.1.0",
+    "@serialport/parser-byte-length": "9.0.7",
+    "@serialport/parser-cctalk": "9.0.7",
+    "@serialport/parser-delimiter": "9.0.7",
+    "@serialport/parser-inter-byte-timeout": "9.0.7",
+    "@serialport/parser-readline": "9.0.7",
+    "@serialport/parser-ready": "9.0.7",
+    "@serialport/parser-regex": "9.0.7",
+    "@serialport/stream": "9.0.7",
     "debug": "^4.3.1"
   },
   "engines": {

--- a/packages/terminal/package-lock.json
+++ b/packages/terminal/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@serialport/terminal",
-      "version": "9.0.4",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
-        "@serialport/bindings": "^9.0.4",
-        "@serialport/stream": "^9.0.2",
+        "@serialport/bindings": "9.1.0",
+        "@serialport/stream": "9.0.7",
         "commander": "^7.1.0",
         "enquirer": "^2.3.5"
       },
@@ -18,65 +18,83 @@
         "serialport-terminal": "lib/index.js"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+      "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/bindings": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-      "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
+      "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "@serialport/parser-readline": "^9.0.1",
+        "@serialport/binding-abstract": "^9.0.7",
+        "@serialport/parser-readline": "^9.0.7",
         "bindings": "^1.5.0",
         "debug": "^4.3.1",
         "nan": "^2.14.2",
-        "prebuild-install": "^6.0.0"
+        "prebuild-install": "^6.0.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==",
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
       "dependencies": {
-        "@serialport/parser-delimiter": "^9.0.1"
+        "@serialport/parser-delimiter": "^9.0.7"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/@serialport/stream": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.2.tgz",
-      "integrity": "sha512-0RkVe+gvwZu/PPfbb7ExQ+euGoCTGKD/B8TQ5fuhe+eKk1sh73RwjKmu9gp6veSNqx9Zljnh1dF6mhdEKWZpSA==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
+      "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/ansi-colors": {
@@ -693,45 +711,45 @@
   },
   "dependencies": {
     "@serialport/binding-abstract": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.2.tgz",
-      "integrity": "sha512-kyMX6usn+VLpidt0YsDq5JwztIan9TPCX6skr0XcalOxI8I7w+/2qVZJzjgo2fSqDnPRcU2jMWTytwzEXFODvQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
+      "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       }
     },
     "@serialport/bindings": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.0.4.tgz",
-      "integrity": "sha512-6dlE1vm5c1xk667f1Zm7D+msbHJ9jdnUr9l8DResKpj2iCBzbCNsW+yCYq26WxzXWc1L2HUaS3/aL+k0wm5amg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
+      "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
       "requires": {
-        "@serialport/binding-abstract": "^9.0.2",
-        "@serialport/parser-readline": "^9.0.1",
+        "@serialport/binding-abstract": "^9.0.7",
+        "@serialport/parser-readline": "^9.0.7",
         "bindings": "^1.5.0",
         "debug": "^4.3.1",
         "nan": "^2.14.2",
-        "prebuild-install": "^6.0.0"
+        "prebuild-install": "^6.0.1"
       }
     },
     "@serialport/parser-delimiter": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.1.tgz",
-      "integrity": "sha512-+oaSl5zEu47OlrRiF5p5tn2qgGqYuhVcE+NI+Pv4E1xsNB/A0fFxxMv/8XUw466CRLEJ5IESIB9qbFvKE6ltaQ=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
+      "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ=="
     },
     "@serialport/parser-readline": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.1.tgz",
-      "integrity": "sha512-38058gxvyfgdeLpg3aUyD98NuWkVB9yyTLpcSdeQ3GYiupivwH6Tdy/SKPmxlHIw3Ml2qil5MR2mtW2fLPB5CQ==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
+      "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
       "requires": {
-        "@serialport/parser-delimiter": "^9.0.1"
+        "@serialport/parser-delimiter": "^9.0.7"
       }
     },
     "@serialport/stream": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.2.tgz",
-      "integrity": "sha512-0RkVe+gvwZu/PPfbb7ExQ+euGoCTGKD/B8TQ5fuhe+eKk1sh73RwjKmu9gp6veSNqx9Zljnh1dF6mhdEKWZpSA==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
+      "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
       }
     },
     "ansi-colors": {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -6,8 +6,8 @@
     "serialport-terminal": "./lib/index.js"
   },
   "dependencies": {
-    "@serialport/bindings": "^9.1.0",
-    "@serialport/stream": "^9.0.7",
+    "@serialport/bindings": "9.1.0",
+    "@serialport/stream": "9.0.7",
     "commander": "^7.1.0",
     "enquirer": "^2.3.5"
   },


### PR DESCRIPTION
The goal here (https://github.com/serialport/node-serialport/issues/2270) is to ensure that you get a binding version that matches the serialport version. So if you downgrade serialport you'll get a downgraded bindings package too. This wont work retroactively but should help going forward.