### PR TITLE
Lerna changed to use exact version dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "outdated": "lerna exec --no-bail npm outdated && npm outdated",
     "postinstall": "lerna bootstrap --no-ci",
     "prebuild": "lerna run --stream prebuild",
-    "publish": "lerna publish",
+    "publish": "lerna publish --exact",
     "test": "nyc --reporter=html --reporter=text --reporter lcovonly mocha",
     "test:arduino": "TEST_PORT=$(./bin/find-arduino.js) npm test",
     "test:watch": "mocha -w"


### PR DESCRIPTION
Change dependencies of the serialport package to use exact versions. e.g. serialport 9.0.0 would have a dependency on "@serialport/bindings": "9.0.0" instead of "@serialport/bindings": "^9.0.0"

Config Lerna to publish exact version dependencies per https://github.com/serialport/node-serialport/issues/2270