### PR TITLE
Ignore end of line prettier errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,8 @@
         "trailingComma": "es5",
         "semi": false,
         "printWidth": 150,
-        "arrowParens": "avoid"
+        "arrowParens": "avoid",
+        "endOfLine": "auto"
       }
     ],
     "mocha/no-exclusive-tests": "error",


### PR DESCRIPTION
Override the default lint rule for End of Line introduced in Prettier v2.0.0 (i.e. revert to "auto" rather than forcing "LF")

While there are other options to address this, this change simply suppresses the "error" rather than touching every single line within 70+ files

See [prettier options](https://prettier.io/docs/en/options.html#end-of-line) for more info

Perhaps we could find a good suitable time to switch most/all of the linting rules over to the default, but I fear it will make it quite messy to trace the history of commits if a lint change touches every line in every file...

Signed-off-by: Gareth Hancock <gazhank@gmail.com>