### PR TITLE
Use Dependabot to keep node-abi up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      # Allow updates for node-abi
+      - dependency-name: "node-abi"
+    # Prefix all commit messages with "Composer"
+    # include a list of updated dependencies
+    commit-message:
+      prefix: "Chore: "
+      include: "scope"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/packages/bindings/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      # Allow updates for node-abi
+      - dependency-name: "node-abi"
+    # Prefix all commit messages with "Composer"
+    # include a list of updated dependencies
+    commit-message:
+      prefix: "Chore: "
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,16 +17,3 @@ updates:
     commit-message:
       prefix: "Chore: "
       include: "scope"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/bindings/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      # Allow updates for node-abi
-      - dependency-name: "node-abi"
-    # Prefix all commit messages with "Composer"
-    # include a list of updated dependencies
-    commit-message:
-      prefix: "Chore: "
-      include: "scope"


### PR DESCRIPTION
This is an attempt to stay on top of updates to node and electron versions as they are released.  We could use Dependabot for more updates, but I thought it safest to try this out with a narrow scope for now

Proposed per discussion https://github.com/serialport/node-serialport/discussions/2289