### PR TITLE
Fixed EIO_List to prevent crash when a device has no COM port

### DIFF
--- a/packages/bindings/src/serialport_win.cpp
+++ b/packages/bindings/src/serialport_win.cpp
@@ -798,6 +798,7 @@ void EIO_List(uv_work_t* req) {
   char serialNumber[MAX_REGISTRY_KEY_SIZE];
   bool isCom;
   while (true) {
+    isCom = false;
     pnpId = NULL;
     vendorId = NULL;
     productId = NULL;


### PR DESCRIPTION
Fixed EIO_List to prevent crash when a device has no COM port, see:
https://github.com/serialport/node-serialport/issues/1830
https://github.com/serialport/node-serialport/issues/2259
https://github.com/serialport/node-serialport/issues/2155