### PR TITLE
serialport_unix: Include sys/ioctl.h on NetBSD

### DIFF
--- a/packages/bindings/src/serialport_unix.cpp
+++ b/packages/bindings/src/serialport_unix.cpp
@@ -16,6 +16,9 @@
 #include <sys/ioctl.h>
 #include <IOKit/serial/ioss.h>
 
+#elif defined(__NetBSD__)
+#include <sys/ioctl.h>
+
 #elif defined(__OpenBSD__)
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
Resolves failure to compile because ioctl() is not defined.  This
simply mirrors the OpenBSD ifdef.  Compile tested on NetBSD 9 amd64.