### PR TITLE
fix: build binaries for every lerna release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     tags:
-    - '@serialport/bindings@[1-9]+.[0-9]+.[0-9]+'
+    - 'v[1-9]+.[0-9]+.[0-9]+'
     - 'force-build'
 jobs:
   test:

--- a/packages/bindings/.prebuild-installrc
+++ b/packages/bindings/.prebuild-installrc
@@ -1,3 +1,3 @@
 {
-  "tag-prefix": "@serialport/bindings@"
+  "tag-prefix": "v"
 }

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -21,9 +21,9 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "install": "prebuild-install --tag-prefix @serialport/bindings@ || node-gyp rebuild",
+    "install": "prebuild-install --tag-prefix v || node-gyp rebuild",
     "lint": "cc --verbose",
-    "prebuild": "prebuild --all --force --strip --verbose --tag-prefix @serialport/bindings@",
+    "prebuild": "prebuild --all --force --strip --verbose --tag-prefix v",
     "rebuild": "node-gyp rebuild"
   },
   "publishConfig": {


### PR DESCRIPTION
I'm unsure if this is the best approach as it's not about when bindings is released but when any new version is released. That's not ideal.
