### PR TITLE
🐛🔗 broken link: fix 'Guides' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Access serial ports with JavaScript. Linux, OSX and Windows. Welcome your roboti
 > Go to https://serialport.io/ to learn more, find guides and api documentation.
 
 ## Quick Links
-- [**Guides**](https://serialport.io/docs/guide-about)
+- [**Guides**](https://serialport.io/docs/)
 - [**API Docs**](https://serialport.io/docs/api-serialport)
 - [The `serialport` package api docs](https://serialport.io/docs/api-serialport)
 


### PR DESCRIPTION
Fixed broken link for guides

previously, the link was referred to [https://serialport.io/docs/guide-about](https://serialport.io/docs/guide-about). But, it was showing `Page Not Found`.  The closed link for the guide (or the docs) is [https://serialport.io/docs/](https://serialport.io/docs/).

![image](https://user-images.githubusercontent.com/44049528/142646252-e5b9164e-1b38-40a2-86a4-19688b5a95e5.png)
