### PR TITLE
fix: run build as part of lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm run typecheck
+    - run: npm run build
   test:
     runs-on: ${{ matrix.config.os }}
     strategy:


### PR DESCRIPTION
build uses a variant of the tsconfig files and might have different results