### PR TITLE
feat: platform specific open options for streams

### DIFF
--- a/packages/serialport/lib/index.test.ts
+++ b/packages/serialport/lib/index.test.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto'
 import { SerialPort as SerialPortAutoDetect, SerialPortMock } from './'
 import { assert } from '../../../test/assert'
 import { testOnPlatform } from '../../../test/testOnPlatform'
+import { LinuxBinding, LinuxOpenOptions } from '@serialport/bindings-cpp'
 
 const platform = process.platform
 if (platform !== 'win32' && platform !== 'darwin' && platform !== 'linux') {
@@ -31,13 +32,13 @@ function testSerialPortClass(
 
     beforeEach(() => {
       if (platform === 'mock') {
-        SerialPortMock.MockBinding.createPort('/dev/exists', { echo: true, maxReadSize: 50 })
+        SerialPortMock.binding.createPort('/dev/exists', { echo: true, maxReadSize: 50 })
       }
     })
 
     afterEach(() => {
       if (platform === 'mock') {
-        SerialPortMock.MockBinding.reset()
+        SerialPortMock.binding.reset()
       }
     })
 
@@ -70,6 +71,16 @@ function testSerialPortClass(
         const port = new SerialPort({ ...openOptions, path: 'COM99' })
         port.on('error', err => {
           assert.instanceOf(err, Error)
+          done()
+        })
+      })
+
+      it('allows platform specific options', done => {
+        new SerialPort({
+          path: '/bad/port',
+          baudRate: 9600,
+          vmin: 10,
+        } as LinuxOpenOptions).on('error', () => {
           done()
         })
       })

--- a/packages/serialport/lib/serialport-mock.ts
+++ b/packages/serialport/lib/serialport-mock.ts
@@ -5,7 +5,7 @@ export type SerialPortMockOpenOptions = Omit<OpenOptions<MockBindingInterface>, 
 
 export class SerialPortMock extends SerialPortStream<MockBindingInterface> {
   static list = MockBinding.list
-  static readonly MockBinding = MockBinding
+  static readonly binding = MockBinding
 
   constructor(options: SerialPortMockOpenOptions, openCallback?: ErrorCallback) {
     const opts: OpenOptions<MockBindingInterface> = {

--- a/packages/serialport/lib/serialport.ts
+++ b/packages/serialport/lib/serialport.ts
@@ -1,11 +1,11 @@
-import { ErrorCallback, OpenOptions, SerialPortStream } from '@serialport/stream'
-import { autoDetect, AutoDetectTypes } from '@serialport/bindings-cpp'
+import { ErrorCallback, OpenOptions, SerialPortStream, StreamOptions } from '@serialport/stream'
+import { autoDetect, AutoDetectTypes, OpenOptionsFromBinding } from '@serialport/bindings-cpp'
 
 const DetectedBinding = autoDetect()
 
-export type SerialPortOpenOptions = Omit<OpenOptions<AutoDetectTypes>, 'binding'>
+export type SerialPortOpenOptions<T extends AutoDetectTypes> = Omit<StreamOptions<T>, 'binding'> & OpenOptionsFromBinding<T>
 
-export class SerialPort extends SerialPortStream<AutoDetectTypes> {
+export class SerialPort<T extends AutoDetectTypes = AutoDetectTypes> extends SerialPortStream<T> {
   /**
    * Retrieves a list of available serial ports with metadata. Only the `path` is guaranteed. If unavailable the other fields will be undefined. The `path` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
    *
@@ -57,10 +57,11 @@ export class SerialPort extends SerialPortStream<AutoDetectTypes> {
   ```
   */
   static list = DetectedBinding.list
+  static readonly binding = DetectedBinding
 
-  constructor(options: SerialPortOpenOptions, openCallback?: ErrorCallback) {
-    const opts: OpenOptions<AutoDetectTypes> = {
-      binding: DetectedBinding,
+  constructor(options: SerialPortOpenOptions<T>, openCallback?: ErrorCallback) {
+    const opts: OpenOptions<T> = {
+      binding: DetectedBinding as T,
       ...options,
     }
     super(opts, openCallback)

--- a/packages/terminal/lib/index.ts
+++ b/packages/terminal/lib/index.ts
@@ -30,7 +30,7 @@ const args = program.opts<{
   path?: string
   baud: number
   databits: 8 | 7 | 6 | 5
-  parity: string
+  parity: OpenOptions<AutoDetectTypes>['parity']
   stopbits: 1 | 1.5 | 2
   echo: boolean
   flowCtl?: string


### PR DESCRIPTION
Make it a bit easier to have platform specific open options. I'm in love with the solution but it doesn't seem possible to filter the generic via a typecheck and have it apply to the constructor options on a serialport stream. So casting the open options is the only recourse I've figured out.

```ts
new SerialPort({
  path: '/bad/port',
  baudRate: 9600,
  vmin: 10,
} as LinuxOpenOptions)
```