### PR TITLE
docs: broken link: fix 'bindings-cpp' link

### DIFF
--- a/packages/serialport/README.md
+++ b/packages/serialport/README.md
@@ -17,7 +17,7 @@ Access serial ports with JavaScript. Linux, OSX and Windows. Welcome your roboti
 
 The Bindings provide a low level interface to work with your serialport. It is possible to use them alone but it's usually easier to use them with an interface.
 
-- [`@serialport/bindings-cpp`](https://serialport.io/docs/api-bindings) bindings for Linux, Mac and Windows
+- [`@serialport/bindings-cpp`](https://serialport.io/docs/api-bindings-cpp) bindings for Linux, Mac and Windows
 - [`@serialport/bindings-interface`](https://serialport.io/docs/api-bindings-interface) a typescript interface to use if you're making your own bindings
 - [`@serialport/binding-mock`](https://serialport.io/docs/api-binding-mock) for a mock binding package for testing
 


### PR DESCRIPTION
Fixed broken link for bindings-cpp.