### PR TITLE
Fix encoding for stream _write

### DIFF
--- a/packages/stream/lib/index.ts
+++ b/packages/stream/lib/index.ts
@@ -246,7 +246,7 @@ export class SerialPortStream<T extends BindingInterface = BindingInterface> ext
     return super.write(data, encoding, callback)
   }
 
-  _write(data: Buffer, encoding: BufferEncoding | undefined, callback: (error: Error | null) => void) {
+  _write(data: Buffer, encoding: BufferEncoding, callback: (error: Error | null) => void) {
     if (!this.isOpen || !this.port) {
       this.once('open', () => {
         this._write(data, encoding, callback)


### PR DESCRIPTION
Fix per https://github.com/serialport/node-serialport/issues/2566

This matches the definition of _write definition for Duplex streams

Signed-off-by: Gareth Hancock <64541249+GazHank@users.noreply.github.com>