### PR TITLE
Migrate to NPM workspaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
         config:
           # arch isn't used and we have no way to use it currently
           - { os: macos-latest, arch: x64 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "serialport-monorepo",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
       "devDependencies": {
         "@serialport/bindings-cpp": "11.0.1",
         "@tsconfig/node14": "1.0.3",
@@ -3431,11 +3433,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@serialport/binding-mock": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+      "dependencies": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@serialport/bindings-cpp": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-11.0.1.tgz",
       "integrity": "sha512-3I1mniVg3osYuIUXxU0jB5AHPsxWmErmc3JC3WfUSlfXsjWMHkHfFzbW9Scuv/z/6DLCJIDyltabRa2FoW2qsQ==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@serialport/bindings-interface": "1.2.2",
@@ -3451,20 +3464,10 @@
         "url": "https://opencollective.com/serialport/donate"
       }
     },
-    "node_modules/@serialport/bindings-interface": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/@serialport/parser-delimiter": {
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
       "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
-      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -3472,11 +3475,10 @@
         "url": "https://opencollective.com/serialport/donate"
       }
     },
-    "node_modules/@serialport/parser-readline": {
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
       "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
-      "dev": true,
       "dependencies": {
         "@serialport/parser-delimiter": "10.5.0"
       },
@@ -3486,6 +3488,70 @@
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
+    },
+    "node_modules/@serialport/bindings-interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
+      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@serialport/list": {
+      "resolved": "packages/list",
+      "link": true
+    },
+    "node_modules/@serialport/parser-byte-length": {
+      "resolved": "packages/parser-byte-length",
+      "link": true
+    },
+    "node_modules/@serialport/parser-cctalk": {
+      "resolved": "packages/parser-cctalk",
+      "link": true
+    },
+    "node_modules/@serialport/parser-delimiter": {
+      "resolved": "packages/parser-delimiter",
+      "link": true
+    },
+    "node_modules/@serialport/parser-inter-byte-timeout": {
+      "resolved": "packages/parser-inter-byte-timeout",
+      "link": true
+    },
+    "node_modules/@serialport/parser-packet-length": {
+      "resolved": "packages/parser-packet-length",
+      "link": true
+    },
+    "node_modules/@serialport/parser-readline": {
+      "resolved": "packages/parser-readline",
+      "link": true
+    },
+    "node_modules/@serialport/parser-ready": {
+      "resolved": "packages/parser-ready",
+      "link": true
+    },
+    "node_modules/@serialport/parser-regex": {
+      "resolved": "packages/parser-regex",
+      "link": true
+    },
+    "node_modules/@serialport/parser-slip-encoder": {
+      "resolved": "packages/parser-slip-encoder",
+      "link": true
+    },
+    "node_modules/@serialport/parser-spacepacket": {
+      "resolved": "packages/parser-spacepacket",
+      "link": true
+    },
+    "node_modules/@serialport/repl": {
+      "resolved": "packages/repl",
+      "link": true
+    },
+    "node_modules/@serialport/stream": {
+      "resolved": "packages/stream",
+      "link": true
+    },
+    "node_modules/@serialport/terminal": {
+      "resolved": "packages/terminal",
+      "link": true
     },
     "node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
@@ -4066,7 +4132,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4937,6 +5002,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -5230,7 +5303,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5537,7 +5609,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -10056,8 +10127,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -10159,8 +10229,7 @@
     "node_modules/node-addon-api": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "dev": true
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -10210,7 +10279,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -12518,6 +12586,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/promirepl": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promirepl/-/promirepl-2.0.1.tgz",
+      "integrity": "sha512-CUYuyU858eJ4OuQLKhJTE1Mijb1zxuAOnmVSYysau1k58zxT9qf0bJb/3QYrYadzmyuLn4EB82Oki+uHmWqC0w==",
+      "bin": {
+        "prominode": "bin/prominode.js"
+      },
+      "engines": {
+        "node": "^8"
+      }
+    },
     "node_modules/promise-all-reject-late": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
@@ -13252,6 +13331,10 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/serialport": {
+      "resolved": "packages/serialport",
+      "link": true
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -15051,6 +15134,245 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/list": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-cpp": "11.0.1",
+        "commander": "10.0.1"
+      },
+      "bin": {
+        "serialport-list": "dist/index.js"
+      },
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-byte-length": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-cctalk": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-delimiter": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-inter-byte-timeout": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-packet-length": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "packages/parser-readline": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/parser-delimiter": "11.0.0"
+      },
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-ready": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-regex": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-slip-encoder": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/parser-spacepacket": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/repl": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "promirepl": "^2.0.1",
+        "serialport": "11.0.0"
+      },
+      "bin": {
+        "serialport-repl": "dist/index.js"
+      },
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/serialport": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "11.0.1",
+        "@serialport/parser-byte-length": "11.0.0",
+        "@serialport/parser-cctalk": "11.0.0",
+        "@serialport/parser-delimiter": "11.0.0",
+        "@serialport/parser-inter-byte-timeout": "11.0.0",
+        "@serialport/parser-packet-length": "11.0.0",
+        "@serialport/parser-readline": "11.0.0",
+        "@serialport/parser-ready": "11.0.0",
+        "@serialport/parser-regex": "11.0.0",
+        "@serialport/parser-slip-encoder": "11.0.0",
+        "@serialport/parser-spacepacket": "11.0.0",
+        "@serialport/stream": "11.0.0",
+        "debug": "4.3.4"
+      },
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/stream": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "4.3.4"
+      },
+      "devDependencies": {
+        "@serialport/binding-mock": "^10.2.2",
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "packages/terminal": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-cpp": "11.0.1",
+        "@serialport/stream": "11.0.0",
+        "commander": "10.0.1",
+        "enquirer": "2.3.6"
+      },
+      "bin": {
+        "serialport-terminal": "dist/index.js"
+      },
+      "devDependencies": {
+        "typescript": "5.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     }
   },
@@ -17494,38 +17816,141 @@
       "dev": true,
       "optional": true
     },
+    "@serialport/binding-mock": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+      "requires": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      }
+    },
     "@serialport/bindings-cpp": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-11.0.1.tgz",
       "integrity": "sha512-3I1mniVg3osYuIUXxU0jB5AHPsxWmErmc3JC3WfUSlfXsjWMHkHfFzbW9Scuv/z/6DLCJIDyltabRa2FoW2qsQ==",
-      "dev": true,
       "requires": {
         "@serialport/bindings-interface": "1.2.2",
         "@serialport/parser-readline": "10.5.0",
         "debug": "4.3.4",
         "node-addon-api": "6.1.0",
         "node-gyp-build": "4.6.0"
+      },
+      "dependencies": {
+        "@serialport/parser-delimiter": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
+          "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
+        },
+        "@serialport/parser-readline": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
+          "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
+          "requires": {
+            "@serialport/parser-delimiter": "10.5.0"
+          }
+        }
       }
     },
     "@serialport/bindings-interface": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
-      "dev": true
+      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA=="
+    },
+    "@serialport/list": {
+      "version": "file:packages/list",
+      "requires": {
+        "@serialport/bindings-cpp": "11.0.1",
+        "commander": "10.0.1",
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-byte-length": {
+      "version": "file:packages/parser-byte-length",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-cctalk": {
+      "version": "file:packages/parser-cctalk",
+      "requires": {
+        "typescript": "5.0.4"
+      }
     },
     "@serialport/parser-delimiter": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-      "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
-      "dev": true
+      "version": "file:packages/parser-delimiter",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-inter-byte-timeout": {
+      "version": "file:packages/parser-inter-byte-timeout",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-packet-length": {
+      "version": "file:packages/parser-packet-length",
+      "requires": {
+        "typescript": "5.0.4"
+      }
     },
     "@serialport/parser-readline": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
-      "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
-      "dev": true,
+      "version": "file:packages/parser-readline",
       "requires": {
-        "@serialport/parser-delimiter": "10.5.0"
+        "@serialport/parser-delimiter": "11.0.0",
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-ready": {
+      "version": "file:packages/parser-ready",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-regex": {
+      "version": "file:packages/parser-regex",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-slip-encoder": {
+      "version": "file:packages/parser-slip-encoder",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/parser-spacepacket": {
+      "version": "file:packages/parser-spacepacket",
+      "requires": {
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/repl": {
+      "version": "file:packages/repl",
+      "requires": {
+        "promirepl": "^2.0.1",
+        "serialport": "11.0.0",
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/stream": {
+      "version": "file:packages/stream",
+      "requires": {
+        "@serialport/binding-mock": "^10.2.2",
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "4.3.4",
+        "typescript": "5.0.4"
+      }
+    },
+    "@serialport/terminal": {
+      "version": "file:packages/terminal",
+      "requires": {
+        "@serialport/bindings-cpp": "11.0.1",
+        "@serialport/stream": "11.0.0",
+        "commander": "10.0.1",
+        "enquirer": "2.3.6",
+        "typescript": "5.0.4"
       }
     },
     "@sigstore/protobuf-specs": {
@@ -17970,8 +18395,7 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -18607,6 +19031,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+    },
     "common-ancestor-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -18844,7 +19273,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -19075,7 +19503,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -22482,8 +22909,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "5.0.0",
@@ -22569,8 +22995,7 @@
     "node-addon-api": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "dev": true
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -22795,8 +23220,7 @@
     "node-gyp-build": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "dev": true
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-preload": {
       "version": "0.2.1",
@@ -24373,6 +24797,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promirepl": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promirepl/-/promirepl-2.0.1.tgz",
+      "integrity": "sha512-CUYuyU858eJ4OuQLKhJTE1Mijb1zxuAOnmVSYysau1k58zxT9qf0bJb/3QYrYadzmyuLn4EB82Oki+uHmWqC0w=="
+    },
     "promise-all-reject-late": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
@@ -24927,6 +25356,26 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "serialport": {
+      "version": "file:packages/serialport",
+      "requires": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "11.0.1",
+        "@serialport/parser-byte-length": "11.0.0",
+        "@serialport/parser-cctalk": "11.0.0",
+        "@serialport/parser-delimiter": "11.0.0",
+        "@serialport/parser-inter-byte-timeout": "11.0.0",
+        "@serialport/parser-packet-length": "11.0.0",
+        "@serialport/parser-readline": "11.0.0",
+        "@serialport/parser-ready": "11.0.0",
+        "@serialport/parser-regex": "11.0.0",
+        "@serialport/parser-slip-encoder": "11.0.0",
+        "@serialport/parser-spacepacket": "11.0.0",
+        "@serialport/stream": "11.0.0",
+        "debug": "4.3.4",
+        "typescript": "5.0.4"
       }
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
   },
-  "workspaces": ["./packages/*"],
+  "workspaces": [
+    "./packages/*"
+  ],
   "devDependencies": {
     "@serialport/bindings-cpp": "11.0.1",
     "@tsconfig/node14": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "format": "npx prettier --write . && eslint packages test --fix",
     "lint": "eslint packages test && npx prettier --check .",
     "outdated": "lerna exec --no-bail npm outdated && npm outdated",
-    "postinstall": "lerna bootstrap --no-ci",
     "publish": "lerna publish --exact",
     "test:arduino": "TEST_PORT=$(./bin/find-arduino.ts) npm test",
     "test:watch": "mocha -w",
@@ -23,6 +22,7 @@
     "type": "git",
     "url": "git://github.com/serialport/node-serialport.git"
   },
+  "workspaces": ["./packages/*"],
   "devDependencies": {
     "@serialport/bindings-cpp": "11.0.1",
     "@tsconfig/node14": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Node.js packages to access serial ports, process data from them and speak many protocols",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Allows upgrade to Lerna v7 removing it's legacy package management

**Breaking change:**
Drops support for Node 14 (since node 15+ is required for workspaces)