### PR TITLE
Revert "chore(deps): update dependency lerna to v6.6.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-mocha": "10.1.0",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-promise": "6.1.1",
-        "lerna": "6.6.2",
+        "lerna": "6.6.1",
         "lerna-changelog": "2.2.0",
         "mocha": "10.2.0",
         "nyc": "^15.1.0",
@@ -1043,9 +1043,9 @@
       }
     },
     "node_modules/@lerna/child-process": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-6.6.2.tgz",
-      "integrity": "sha512-QyKIWEnKQFnYu2ey+SAAm1A5xjzJLJJj3bhIZd3QKyXKKjaJ0hlxam/OsWSltxTNbcyH1jRJjC6Cxv31usv0Ag==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-6.6.1.tgz",
+      "integrity": "sha512-yUCDCcRNNbI9UUsUB6FYEmDHpo5Tn/f0q5D7vhDP4i6Or8kBj82y7+e31hwfLvK2ykOYlDVs2MxAluH/+QUBOQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -1053,22 +1053,22 @@
         "strong-log-transformer": "^2.1.0"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@lerna/create": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-6.6.2.tgz",
-      "integrity": "sha512-xQ+1Y7D+9etvUlE+unhG/TwmM6XBzGIdFBaNoW8D8kyOa9M2Jf3vdEtAxVa7mhRz66CENfhL/+I/QkVaa7pwbQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-6.6.1.tgz",
+      "integrity": "sha512-GDmHFhQ0mr0RcXWXrsLyfMV6ch/dZV/Ped1e6sFVQhsLL9P+FFXX1ZWxa/dQQ90VWF2qWcmK0+S/L3kUz2xvTA==",
       "dev": true,
       "dependencies": {
-        "@lerna/child-process": "6.6.2",
+        "@lerna/child-process": "6.6.1",
         "dedent": "^0.7.0",
         "fs-extra": "^9.1.0",
         "init-package-json": "^3.0.2",
         "npm-package-arg": "8.1.1",
         "p-reduce": "^2.1.0",
-        "pacote": "15.1.1",
+        "pacote": "^13.6.1",
         "pify": "^5.0.0",
         "semver": "^7.3.4",
         "slash": "^3.0.0",
@@ -1077,13 +1077,13 @@
         "yargs-parser": "20.2.4"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@lerna/legacy-package-management": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@lerna/legacy-package-management/-/legacy-package-management-6.6.2.tgz",
-      "integrity": "sha512-0hZxUPKnHwehUO2xC4ldtdX9bW0W1UosxebDIQlZL2STnZnA2IFmIk2lJVUyFW+cmTPQzV93jfS0i69T9Z+teg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@lerna/legacy-package-management/-/legacy-package-management-6.6.1.tgz",
+      "integrity": "sha512-0EYxSFr34VgeudA5rvjGJSY7s4seITMVB7AJ9LRFv9QDUk6jpvapV13ZAaKnhDTxX5vNCfnJuWHXXWq0KyPF/Q==",
       "dev": true,
       "dependencies": {
         "@npmcli/arborist": "6.2.3",
@@ -1115,7 +1115,7 @@
         "inquirer": "8.2.4",
         "is-ci": "2.0.0",
         "is-stream": "2.0.0",
-        "libnpmpublish": "7.1.4",
+        "libnpmpublish": "6.0.4",
         "load-json-file": "6.2.0",
         "make-dir": "3.1.0",
         "minimatch": "3.0.5",
@@ -1129,7 +1129,7 @@
         "p-map-series": "2.1.0",
         "p-queue": "6.6.2",
         "p-waterfall": "2.1.1",
-        "pacote": "15.1.1",
+        "pacote": "13.6.2",
         "pify": "5.0.0",
         "pretty-format": "29.4.3",
         "read-cmd-shim": "3.0.0",
@@ -1150,7 +1150,7 @@
         "yargs": "16.2.0"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@lerna/legacy-package-management/node_modules/@npmcli/fs": {
@@ -1819,6 +1819,25 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@npmcli/arborist/node_modules/@npmcli/git": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.0.4.tgz",
+      "integrity": "sha512-5yZghx+u5M47LghaybLCkdSyFzV/w4OuH12d96HO389Ik9CDsLaDZJVynSGGVJOLn6gy/k7Dz5XYcplM3uxXRg==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/promise-spawn": "^6.0.0",
+        "lru-cache": "^7.4.4",
+        "npm-pick-manifest": "^8.0.0",
+        "proc-log": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/@npmcli/arborist/node_modules/@npmcli/promise-spawn": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
@@ -2281,34 +2300,35 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
-      "integrity": "sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-3.0.2.tgz",
+      "integrity": "sha512-CAcd08y3DWBJqJDpfuVL0uijlq5oaXaOJEKHKc4wqrjd00gkvTZB+nFuLn+doOOKddaQS9JfqtNoFCO2LCvA3w==",
       "dev": true,
       "dependencies": {
-        "@npmcli/promise-spawn": "^6.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
         "lru-cache": "^7.4.4",
-        "npm-pick-manifest": "^8.0.0",
-        "proc-log": "^3.0.0",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^3.0.0"
+        "which": "^2.0.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/@npmcli/git/node_modules/@npmcli/promise-spawn": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-      "integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+    "node_modules/@npmcli/git/node_modules/hosted-git-info": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+      "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
       "dev": true,
       "dependencies": {
-        "which": "^3.0.0"
+        "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
@@ -2320,19 +2340,64 @@
         "node": ">=12"
       }
     },
-    "node_modules/@npmcli/git/node_modules/which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+    "node_modules/@npmcli/git/node_modules/npm-install-checks": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz",
+      "integrity": "sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==",
       "dev": true,
       "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
+        "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+      "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/npm-package-arg": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz",
+      "integrity": "sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "proc-log": "^2.0.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/npm-pick-manifest": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.2.tgz",
+      "integrity": "sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==",
+      "dev": true,
+      "dependencies": {
+        "npm-install-checks": "^5.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/proc-log": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+      "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
@@ -2471,6 +2536,25 @@
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/git": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.0.4.tgz",
+      "integrity": "sha512-5yZghx+u5M47LghaybLCkdSyFzV/w4OuH12d96HO389Ik9CDsLaDZJVynSGGVJOLn6gy/k7Dz5XYcplM3uxXRg==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/promise-spawn": "^6.0.0",
+        "lru-cache": "^7.4.4",
+        "npm-pick-manifest": "^8.0.0",
+        "proc-log": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^3.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -8269,14 +8353,14 @@
       }
     },
     "node_modules/lerna": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-6.6.2.tgz",
-      "integrity": "sha512-W4qrGhcdutkRdHEaDf9eqp7u4JvI+1TwFy5woX6OI8WPe4PYBdxuILAsvhp614fUG41rKSGDKlOh+AWzdSidTg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-6.6.1.tgz",
+      "integrity": "sha512-WJtrvmbmR+6hMB9b5pvsxJzew0lRL6hARgW/My9BM4vYaxwPIA2I0riv3qQu5Zd7lYse7FEqJkTnl9Kn1bXhLA==",
       "dev": true,
       "dependencies": {
-        "@lerna/child-process": "6.6.2",
-        "@lerna/create": "6.6.2",
-        "@lerna/legacy-package-management": "6.6.2",
+        "@lerna/child-process": "6.6.1",
+        "@lerna/create": "6.6.1",
+        "@lerna/legacy-package-management": "6.6.1",
         "@npmcli/arborist": "6.2.3",
         "@npmcli/run-script": "4.1.7",
         "@nrwl/devkit": ">=15.5.2 < 16",
@@ -8310,8 +8394,8 @@
         "is-ci": "2.0.0",
         "is-stream": "2.0.0",
         "js-yaml": "^4.1.0",
-        "libnpmaccess": "^6.0.3",
-        "libnpmpublish": "7.1.4",
+        "libnpmaccess": "6.0.3",
+        "libnpmpublish": "6.0.4",
         "load-json-file": "6.2.0",
         "make-dir": "3.1.0",
         "minimatch": "3.0.5",
@@ -8328,7 +8412,7 @@
         "p-queue": "6.6.2",
         "p-reduce": "2.1.0",
         "p-waterfall": "2.1.1",
-        "pacote": "15.1.1",
+        "pacote": "13.6.2",
         "pify": "5.0.0",
         "read-cmd-shim": "3.0.0",
         "read-package-json": "5.0.1",
@@ -8355,7 +8439,7 @@
         "lerna": "dist/cli.js"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/lerna-changelog": {
@@ -8951,49 +9035,138 @@
       }
     },
     "node_modules/libnpmpublish": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-7.1.4.tgz",
-      "integrity": "sha512-mMntrhVwut5prP4rJ228eEbEyvIzLWhqFuY90j5QeXBCTT2pWSMno7Yo2S2qplPUr02zPurGH4heGLZ+wORczg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-6.0.4.tgz",
+      "integrity": "sha512-lvAEYW8mB8QblL6Q/PI/wMzKNvIrF7Kpujf/4fGS/32a2i3jzUXi04TNyIBcK6dQJ34IgywfaKGh+Jq4HYPFmg==",
       "dev": true,
       "dependencies": {
-        "ci-info": "^3.6.1",
-        "normalize-package-data": "^5.0.0",
-        "npm-package-arg": "^10.1.0",
-        "npm-registry-fetch": "^14.0.3",
-        "proc-log": "^3.0.0",
+        "normalize-package-data": "^4.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^1.4.0",
-        "ssri": "^10.0.1"
+        "ssri": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/libnpmpublish/node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+    "node_modules/libnpmpublish/node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
       "engines": {
-        "node": ">=8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/libnpmpublish/node_modules/hosted-git-info": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+      "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/libnpmpublish/node_modules/lru-cache": {
@@ -9005,67 +9178,167 @@
         "node": ">=12"
       }
     },
-    "node_modules/libnpmpublish/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+    "node_modules/libnpmpublish/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
       "dev": true,
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
       "engines": {
-        "node": ">=8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
       }
     },
     "node_modules/libnpmpublish/node_modules/normalize-package-data": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-      "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
+      "integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^6.0.0",
+        "hosted-git-info": "^5.0.0",
         "is-core-module": "^2.8.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/libnpmpublish/node_modules/npm-package-arg": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-      "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz",
+      "integrity": "sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "hosted-git-info": "^5.0.0",
+        "proc-log": "^2.0.1",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
+        "validate-npm-package-name": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/npm-registry-fetch": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.3.1.tgz",
+      "integrity": "sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==",
+      "dev": true,
+      "dependencies": {
+        "make-fetch-happen": "^10.0.6",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^2.0.3",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/proc-log": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+      "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/libnpmpublish/node_modules/ssri": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
-      "integrity": "sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
       "dev": true,
       "dependencies": {
-        "minipass": "^5.0.0"
+        "minipass": "^3.1.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/libnpmpublish/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+    "node_modules/libnpmpublish/node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
       "dev": true,
       "dependencies": {
-        "builtins": "^5.0.0"
+        "unique-slug": "^3.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -11488,75 +11761,90 @@
       }
     },
     "node_modules/pacote": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.1.1.tgz",
-      "integrity": "sha512-eeqEe77QrA6auZxNHIp+1TzHQ0HBKf5V6c8zcaYZ134EJe1lCi+fjXATkNiEEfbG+e50nu02GLvUtmZcGOYabQ==",
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.6.2.tgz",
+      "integrity": "sha512-Gu8fU3GsvOPkak2CkbojR7vjs3k3P9cA6uazKTHdsdV0gpCEQq2opelnEv30KRQWgVzP5Vd/5umjcedma3MKtg==",
       "dev": true,
       "dependencies": {
-        "@npmcli/git": "^4.0.0",
-        "@npmcli/installed-package-contents": "^2.0.1",
-        "@npmcli/promise-spawn": "^6.0.1",
-        "@npmcli/run-script": "^6.0.0",
-        "cacache": "^17.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^4.0.0",
-        "npm-package-arg": "^10.0.0",
-        "npm-packlist": "^7.0.0",
-        "npm-pick-manifest": "^8.0.0",
-        "npm-registry-fetch": "^14.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "@npmcli/run-script": "^4.1.0",
+        "cacache": "^16.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
+        "npm-packlist": "^5.1.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^6.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "sigstore": "^1.0.0",
-        "ssri": "^10.0.0",
+        "read-package-json": "^5.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
         "pacote": "lib/bin.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/pacote/node_modules/@npmcli/fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
       "dev": true,
       "dependencies": {
+        "@gar/promisify": "^1.1.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/pacote/node_modules/@npmcli/promise-spawn": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-      "integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+    "node_modules/pacote/node_modules/@npmcli/installed-package-contents": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
       "dev": true,
       "dependencies": {
-        "which": "^3.0.0"
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "installed-package-contents": "index.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">= 10"
       }
     },
-    "node_modules/pacote/node_modules/@npmcli/run-script": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz",
-      "integrity": "sha512-NCcr1uQo1k5U+SYlnIrbAh3cxy+OQT1VtqiAbxdymSlptbzBb62AjH2xXgjNCoP073hoa1CfCAcwoZ8k96C4nA==",
+    "node_modules/pacote/node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
       "dev": true,
       "dependencies": {
-        "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/promise-spawn": "^6.0.0",
-        "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "which": "^3.0.0"
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pacote/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/pacote/node_modules/brace-expansion": {
@@ -11569,128 +11857,84 @@
       }
     },
     "node_modules/pacote/node_modules/cacache": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.3.tgz",
-      "integrity": "sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==",
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
       "dev": true,
       "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
         "lru-cache": "^7.7.1",
-        "minipass": "^5.0.0",
+        "minipass": "^3.1.6",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
         "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
         "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
+        "unique-filename": "^2.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pacote/node_modules/cacache/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pacote/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/pacote/node_modules/fs-minipass": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
-      "integrity": "sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pacote/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/pacote/node_modules/glob": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/cjs/src/bin.js"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/pacote/node_modules/glob/node_modules/minipass": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-      "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/pacote/node_modules/hosted-git-info": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+      "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/pacote/node_modules/ignore-walk": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz",
-      "integrity": "sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==",
+    "node_modules/pacote/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^9.0.0"
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">= 6"
       }
+    },
+    "node_modules/pacote/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/pacote/node_modules/lru-cache": {
       "version": "7.18.3",
@@ -11701,169 +11945,216 @@
         "node": ">=12"
       }
     },
+    "node_modules/pacote/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/pacote/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
-    "node_modules/pacote/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pacote/node_modules/normalize-package-data": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-      "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+    "node_modules/pacote/node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^6.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
       }
+    },
+    "node_modules/pacote/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+      "dev": true,
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/pacote/node_modules/npm-install-checks": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz",
+      "integrity": "sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pacote/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
     },
     "node_modules/pacote/node_modules/npm-package-arg": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-      "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz",
+      "integrity": "sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "hosted-git-info": "^5.0.0",
+        "proc-log": "^2.0.1",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
+        "validate-npm-package-name": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/pacote/node_modules/npm-packlist": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-7.0.4.tgz",
-      "integrity": "sha512-d6RGEuRrNS5/N84iglPivjaJPxhDbZmlbTwTDX2IbcRHG5bZCdtysYMhwiPvcF4GisXHGn7xsxv+GQ7T/02M5Q==",
+    "node_modules/pacote/node_modules/npm-pick-manifest": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.2.tgz",
+      "integrity": "sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==",
       "dev": true,
       "dependencies": {
-        "ignore-walk": "^6.0.0"
+        "npm-install-checks": "^5.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/pacote/node_modules/read-package-json": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
-      "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
+    "node_modules/pacote/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+      "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pacote/node_modules/npm-registry-fetch": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.3.1.tgz",
+      "integrity": "sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==",
       "dev": true,
       "dependencies": {
-        "glob": "^10.2.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^5.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "make-fetch-happen": "^10.0.6",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^2.0.3",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.1",
+        "proc-log": "^2.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/pacote/node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+    "node_modules/pacote/node_modules/proc-log": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+      "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pacote/node_modules/read-package-json-fast": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
+      "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
+      "dev": true,
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.0",
+        "npm-normalize-package-bin": "^1.0.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/pacote/node_modules/ssri": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
-      "integrity": "sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
       "dev": true,
       "dependencies": {
-        "minipass": "^5.0.0"
+        "minipass": "^3.1.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pacote/node_modules/ssri/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/pacote/node_modules/unique-filename": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
       "dev": true,
       "dependencies": {
-        "unique-slug": "^4.0.0"
+        "unique-slug": "^3.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/pacote/node_modules/unique-slug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pacote/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "dev": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pacote/node_modules/which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/parent-module": {
@@ -11995,13 +12286,13 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
+      "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^9.0.0",
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15359,9 +15650,9 @@
       }
     },
     "@lerna/child-process": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-6.6.2.tgz",
-      "integrity": "sha512-QyKIWEnKQFnYu2ey+SAAm1A5xjzJLJJj3bhIZd3QKyXKKjaJ0hlxam/OsWSltxTNbcyH1jRJjC6Cxv31usv0Ag==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-6.6.1.tgz",
+      "integrity": "sha512-yUCDCcRNNbI9UUsUB6FYEmDHpo5Tn/f0q5D7vhDP4i6Or8kBj82y7+e31hwfLvK2ykOYlDVs2MxAluH/+QUBOQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -15370,18 +15661,18 @@
       }
     },
     "@lerna/create": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-6.6.2.tgz",
-      "integrity": "sha512-xQ+1Y7D+9etvUlE+unhG/TwmM6XBzGIdFBaNoW8D8kyOa9M2Jf3vdEtAxVa7mhRz66CENfhL/+I/QkVaa7pwbQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-6.6.1.tgz",
+      "integrity": "sha512-GDmHFhQ0mr0RcXWXrsLyfMV6ch/dZV/Ped1e6sFVQhsLL9P+FFXX1ZWxa/dQQ90VWF2qWcmK0+S/L3kUz2xvTA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "6.6.2",
+        "@lerna/child-process": "6.6.1",
         "dedent": "^0.7.0",
         "fs-extra": "^9.1.0",
         "init-package-json": "^3.0.2",
         "npm-package-arg": "8.1.1",
         "p-reduce": "^2.1.0",
-        "pacote": "15.1.1",
+        "pacote": "^13.6.1",
         "pify": "^5.0.0",
         "semver": "^7.3.4",
         "slash": "^3.0.0",
@@ -15391,9 +15682,9 @@
       }
     },
     "@lerna/legacy-package-management": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@lerna/legacy-package-management/-/legacy-package-management-6.6.2.tgz",
-      "integrity": "sha512-0hZxUPKnHwehUO2xC4ldtdX9bW0W1UosxebDIQlZL2STnZnA2IFmIk2lJVUyFW+cmTPQzV93jfS0i69T9Z+teg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@lerna/legacy-package-management/-/legacy-package-management-6.6.1.tgz",
+      "integrity": "sha512-0EYxSFr34VgeudA5rvjGJSY7s4seITMVB7AJ9LRFv9QDUk6jpvapV13ZAaKnhDTxX5vNCfnJuWHXXWq0KyPF/Q==",
       "dev": true,
       "requires": {
         "@npmcli/arborist": "6.2.3",
@@ -15425,7 +15716,7 @@
         "inquirer": "8.2.4",
         "is-ci": "2.0.0",
         "is-stream": "2.0.0",
-        "libnpmpublish": "7.1.4",
+        "libnpmpublish": "6.0.4",
         "load-json-file": "6.2.0",
         "make-dir": "3.1.0",
         "minimatch": "3.0.5",
@@ -15439,7 +15730,7 @@
         "p-map-series": "2.1.0",
         "p-queue": "6.6.2",
         "p-waterfall": "2.1.1",
-        "pacote": "15.1.1",
+        "pacote": "13.6.2",
         "pify": "5.0.0",
         "pretty-format": "29.4.3",
         "read-cmd-shim": "3.0.0",
@@ -15970,6 +16261,22 @@
             "semver": "^7.3.5"
           }
         },
+        "@npmcli/git": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.0.4.tgz",
+          "integrity": "sha512-5yZghx+u5M47LghaybLCkdSyFzV/w4OuH12d96HO389Ik9CDsLaDZJVynSGGVJOLn6gy/k7Dz5XYcplM3uxXRg==",
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^6.0.0",
+            "lru-cache": "^7.4.4",
+            "npm-pick-manifest": "^8.0.0",
+            "proc-log": "^3.0.0",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.5",
+            "which": "^3.0.0"
+          }
+        },
         "@npmcli/promise-spawn": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
@@ -16310,28 +16617,29 @@
       }
     },
     "@npmcli/git": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
-      "integrity": "sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-3.0.2.tgz",
+      "integrity": "sha512-CAcd08y3DWBJqJDpfuVL0uijlq5oaXaOJEKHKc4wqrjd00gkvTZB+nFuLn+doOOKddaQS9JfqtNoFCO2LCvA3w==",
       "dev": true,
       "requires": {
-        "@npmcli/promise-spawn": "^6.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
         "lru-cache": "^7.4.4",
-        "npm-pick-manifest": "^8.0.0",
-        "proc-log": "^3.0.0",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^3.0.0"
+        "which": "^2.0.2"
       },
       "dependencies": {
-        "@npmcli/promise-spawn": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-          "integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+        "hosted-git-info": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+          "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
           "dev": true,
           "requires": {
-            "which": "^3.0.0"
+            "lru-cache": "^7.5.1"
           }
         },
         "lru-cache": {
@@ -16340,14 +16648,50 @@
           "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
           "dev": true
         },
-        "which": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-          "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+        "npm-install-checks": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz",
+          "integrity": "sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "semver": "^7.1.1"
           }
+        },
+        "npm-normalize-package-bin": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+          "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
+          "dev": true
+        },
+        "npm-package-arg": {
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz",
+          "integrity": "sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^5.0.0",
+            "proc-log": "^2.0.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-name": "^4.0.0"
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.2.tgz",
+          "integrity": "sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==",
+          "dev": true,
+          "requires": {
+            "npm-install-checks": "^5.0.0",
+            "npm-normalize-package-bin": "^2.0.0",
+            "npm-package-arg": "^9.0.0",
+            "semver": "^7.3.5"
+          }
+        },
+        "proc-log": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+          "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+          "dev": true
         }
       }
     },
@@ -16447,6 +16791,22 @@
           "dev": true,
           "requires": {
             "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/git": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.0.4.tgz",
+          "integrity": "sha512-5yZghx+u5M47LghaybLCkdSyFzV/w4OuH12d96HO389Ik9CDsLaDZJVynSGGVJOLn6gy/k7Dz5XYcplM3uxXRg==",
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^6.0.0",
+            "lru-cache": "^7.4.4",
+            "npm-pick-manifest": "^8.0.0",
+            "proc-log": "^3.0.0",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^2.0.1",
+            "semver": "^7.3.5",
+            "which": "^3.0.0"
           }
         },
         "@npmcli/promise-spawn": {
@@ -20747,14 +21107,14 @@
       "dev": true
     },
     "lerna": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-6.6.2.tgz",
-      "integrity": "sha512-W4qrGhcdutkRdHEaDf9eqp7u4JvI+1TwFy5woX6OI8WPe4PYBdxuILAsvhp614fUG41rKSGDKlOh+AWzdSidTg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-6.6.1.tgz",
+      "integrity": "sha512-WJtrvmbmR+6hMB9b5pvsxJzew0lRL6hARgW/My9BM4vYaxwPIA2I0riv3qQu5Zd7lYse7FEqJkTnl9Kn1bXhLA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "6.6.2",
-        "@lerna/create": "6.6.2",
-        "@lerna/legacy-package-management": "6.6.2",
+        "@lerna/child-process": "6.6.1",
+        "@lerna/create": "6.6.1",
+        "@lerna/legacy-package-management": "6.6.1",
         "@npmcli/arborist": "6.2.3",
         "@npmcli/run-script": "4.1.7",
         "@nrwl/devkit": ">=15.5.2 < 16",
@@ -20788,8 +21148,8 @@
         "is-ci": "2.0.0",
         "is-stream": "2.0.0",
         "js-yaml": "^4.1.0",
-        "libnpmaccess": "^6.0.3",
-        "libnpmpublish": "7.1.4",
+        "libnpmaccess": "6.0.3",
+        "libnpmpublish": "6.0.4",
         "load-json-file": "6.2.0",
         "make-dir": "3.1.0",
         "minimatch": "3.0.5",
@@ -20806,7 +21166,7 @@
         "p-queue": "6.6.2",
         "p-reduce": "2.1.0",
         "p-waterfall": "2.1.1",
-        "pacote": "15.1.1",
+        "pacote": "13.6.2",
         "pify": "5.0.0",
         "read-cmd-shim": "3.0.0",
         "read-package-json": "5.0.1",
@@ -21277,34 +21637,110 @@
       }
     },
     "libnpmpublish": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-7.1.4.tgz",
-      "integrity": "sha512-mMntrhVwut5prP4rJ228eEbEyvIzLWhqFuY90j5QeXBCTT2pWSMno7Yo2S2qplPUr02zPurGH4heGLZ+wORczg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-6.0.4.tgz",
+      "integrity": "sha512-lvAEYW8mB8QblL6Q/PI/wMzKNvIrF7Kpujf/4fGS/32a2i3jzUXi04TNyIBcK6dQJ34IgywfaKGh+Jq4HYPFmg==",
       "dev": true,
       "requires": {
-        "ci-info": "^3.6.1",
-        "normalize-package-data": "^5.0.0",
-        "npm-package-arg": "^10.1.0",
-        "npm-registry-fetch": "^14.0.3",
-        "proc-log": "^3.0.0",
+        "normalize-package-data": "^4.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^1.4.0",
-        "ssri": "^10.0.1"
+        "ssri": "^9.0.0"
       },
       "dependencies": {
-        "ci-info": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+        "@npmcli/fs": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+          "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.1.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/move-file": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+          "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
           "dev": true
         },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "cacache": {
+          "version": "16.1.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+          "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^2.0.0",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
+            "glob": "^8.0.1",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^9.0.0",
+            "tar": "^6.1.11",
+            "unique-filename": "^2.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
         "hosted-git-info": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-          "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+          "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
           "dev": true,
           "requires": {
             "lru-cache": "^7.5.1"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "lru-cache": {
@@ -21313,52 +21749,132 @@
           "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
           "dev": true
         },
-        "minipass": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-          "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+        "make-fetch-happen": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+          "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^6.0.0",
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^16.1.0",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^2.0.3",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^7.0.0",
+            "ssri": "^9.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+          "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.1.2"
+          }
+        },
+        "normalize-package-data": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
+          "integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^5.0.0",
             "is-core-module": "^2.8.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4"
           }
         },
         "npm-package-arg": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-          "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz",
+          "integrity": "sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^6.0.0",
-            "proc-log": "^3.0.0",
+            "hosted-git-info": "^5.0.0",
+            "proc-log": "^2.0.1",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^5.0.0"
+            "validate-npm-package-name": "^4.0.0"
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "13.3.1",
+          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.3.1.tgz",
+          "integrity": "sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==",
+          "dev": true,
+          "requires": {
+            "make-fetch-happen": "^10.0.6",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.3",
+            "minipass-json-stream": "^1.0.1",
+            "minizlib": "^2.1.2",
+            "npm-package-arg": "^9.0.1",
+            "proc-log": "^2.0.0"
+          }
+        },
+        "proc-log": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+          "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+          "dev": true
+        },
+        "socks-proxy-agent": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
           }
         },
         "ssri": {
-          "version": "10.0.4",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
-          "integrity": "sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+          "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
           "dev": true,
           "requires": {
-            "minipass": "^5.0.0"
+            "minipass": "^3.1.1"
           }
         },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+        "unique-filename": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+          "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
           "dev": true,
           "requires": {
-            "builtins": "^5.0.0"
+            "unique-slug": "^3.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+          "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
           }
         }
       }
@@ -23214,61 +23730,69 @@
       }
     },
     "pacote": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.1.1.tgz",
-      "integrity": "sha512-eeqEe77QrA6auZxNHIp+1TzHQ0HBKf5V6c8zcaYZ134EJe1lCi+fjXATkNiEEfbG+e50nu02GLvUtmZcGOYabQ==",
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.6.2.tgz",
+      "integrity": "sha512-Gu8fU3GsvOPkak2CkbojR7vjs3k3P9cA6uazKTHdsdV0gpCEQq2opelnEv30KRQWgVzP5Vd/5umjcedma3MKtg==",
       "dev": true,
       "requires": {
-        "@npmcli/git": "^4.0.0",
-        "@npmcli/installed-package-contents": "^2.0.1",
-        "@npmcli/promise-spawn": "^6.0.1",
-        "@npmcli/run-script": "^6.0.0",
-        "cacache": "^17.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^4.0.0",
-        "npm-package-arg": "^10.0.0",
-        "npm-packlist": "^7.0.0",
-        "npm-pick-manifest": "^8.0.0",
-        "npm-registry-fetch": "^14.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "@npmcli/run-script": "^4.1.0",
+        "cacache": "^16.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
+        "npm-packlist": "^5.1.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^6.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "sigstore": "^1.0.0",
-        "ssri": "^10.0.0",
+        "read-package-json": "^5.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
         "tar": "^6.1.11"
       },
       "dependencies": {
         "@npmcli/fs": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-          "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+          "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
           "dev": true,
           "requires": {
+            "@gar/promisify": "^1.1.3",
             "semver": "^7.3.5"
           }
         },
-        "@npmcli/promise-spawn": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-          "integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+        "@npmcli/installed-package-contents": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+          "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
           "dev": true,
           "requires": {
-            "which": "^3.0.0"
+            "npm-bundled": "^1.1.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
-        "@npmcli/run-script": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz",
-          "integrity": "sha512-NCcr1uQo1k5U+SYlnIrbAh3cxy+OQT1VtqiAbxdymSlptbzBb62AjH2xXgjNCoP073hoa1CfCAcwoZ8k96C4nA==",
+        "@npmcli/move-file": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+          "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^3.0.0",
-            "@npmcli/promise-spawn": "^6.0.0",
-            "node-gyp": "^9.0.0",
-            "read-package-json-fast": "^3.0.0",
-            "which": "^3.0.0"
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
           }
+        },
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+          "dev": true
         },
         "brace-expansion": {
           "version": "2.0.1",
@@ -23280,98 +23804,69 @@
           }
         },
         "cacache": {
-          "version": "17.1.3",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.3.tgz",
-          "integrity": "sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==",
+          "version": "16.1.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+          "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
           "dev": true,
           "requires": {
-            "@npmcli/fs": "^3.1.0",
-            "fs-minipass": "^3.0.0",
-            "glob": "^10.2.2",
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^2.0.0",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
+            "glob": "^8.0.1",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^7.7.1",
-            "minipass": "^5.0.0",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
             "p-map": "^4.0.0",
-            "ssri": "^10.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^9.0.0",
             "tar": "^6.1.11",
-            "unique-filename": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-              "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-              "dev": true
-            }
-          }
-        },
-        "foreground-child": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-          "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "signal-exit": "^4.0.1"
-          }
-        },
-        "fs-minipass": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
-          "integrity": "sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==",
-          "dev": true,
-          "requires": {
-            "minipass": "^5.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-              "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-              "dev": true
-            }
+            "unique-filename": "^2.0.0"
           }
         },
         "glob": {
-          "version": "10.3.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-          "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
           "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^2.0.3",
-            "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-            "path-scurry": "^1.10.1"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "7.0.2",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-              "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
-              "dev": true
-            }
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "hosted-git-info": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-          "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+          "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
           "dev": true,
           "requires": {
             "lru-cache": "^7.5.1"
           }
         },
-        "ignore-walk": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz",
-          "integrity": "sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==",
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
           "dev": true,
           "requires": {
-            "minimatch": "^9.0.0"
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
           }
+        },
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+          "dev": true
         },
         "lru-cache": {
           "version": "7.18.3",
@@ -23379,123 +23874,174 @@
           "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
           "dev": true
         },
+        "make-fetch-happen": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+          "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^16.1.0",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^2.0.3",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^7.0.0",
+            "ssri": "^9.0.0"
+          }
+        },
         "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
-        "minipass": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-          "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+        "minipass-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+          "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^6.0.0",
-            "is-core-module": "^2.8.1",
-            "semver": "^7.3.5",
-            "validate-npm-package-license": "^3.0.4"
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.1.2"
           }
+        },
+        "npm-bundled": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+          "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+          "dev": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-install-checks": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz",
+          "integrity": "sha512-65lUsMI8ztHCxFz5ckCEC44DRvEGdZX5usQFriauxHEwt7upv1FKaQEmAtU0YnOAdwuNWCmk64xYiQABNrEyLA==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.1.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+          "dev": true
         },
         "npm-package-arg": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-          "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.1.2.tgz",
+          "integrity": "sha512-pzd9rLEx4TfNJkovvlBSLGhq31gGu2QDexFPWT19yCDh0JgnRhlBLNo5759N0AJmBk+kQ9Y/hXoLnlgFD+ukmg==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^6.0.0",
-            "proc-log": "^3.0.0",
+            "hosted-git-info": "^5.0.0",
+            "proc-log": "^2.0.1",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^5.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
-        "npm-packlist": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-7.0.4.tgz",
-          "integrity": "sha512-d6RGEuRrNS5/N84iglPivjaJPxhDbZmlbTwTDX2IbcRHG5bZCdtysYMhwiPvcF4GisXHGn7xsxv+GQ7T/02M5Q==",
+        "npm-pick-manifest": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.2.tgz",
+          "integrity": "sha512-gk37SyRmlIjvTfcYl6RzDbSmS9Y4TOBXfsPnoYqTHARNgWbyDiCSMLUpmALDj4jjcTZpURiEfsSHJj9k7EV4Rw==",
           "dev": true,
           "requires": {
-            "ignore-walk": "^6.0.0"
-          }
-        },
-        "read-package-json": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
-          "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
-          "dev": true,
-          "requires": {
-            "glob": "^10.2.2",
-            "json-parse-even-better-errors": "^3.0.0",
-            "normalize-package-data": "^5.0.0",
-            "npm-normalize-package-bin": "^3.0.0"
-          }
-        },
-        "signal-exit": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-          "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
-          "dev": true
-        },
-        "ssri": {
-          "version": "10.0.4",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.4.tgz",
-          "integrity": "sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==",
-          "dev": true,
-          "requires": {
-            "minipass": "^5.0.0"
+            "npm-install-checks": "^5.0.0",
+            "npm-normalize-package-bin": "^2.0.0",
+            "npm-package-arg": "^9.0.0",
+            "semver": "^7.3.5"
           },
           "dependencies": {
-            "minipass": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-              "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+              "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
               "dev": true
             }
           }
         },
-        "unique-filename": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-          "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+        "npm-registry-fetch": {
+          "version": "13.3.1",
+          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.3.1.tgz",
+          "integrity": "sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==",
           "dev": true,
           "requires": {
-            "unique-slug": "^4.0.0"
+            "make-fetch-happen": "^10.0.6",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.3",
+            "minipass-json-stream": "^1.0.1",
+            "minizlib": "^2.1.2",
+            "npm-package-arg": "^9.0.1",
+            "proc-log": "^2.0.0"
+          }
+        },
+        "proc-log": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
+          "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+          "dev": true
+        },
+        "read-package-json-fast": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
+          "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.0",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
+          }
+        },
+        "ssri": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+          "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "unique-filename": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+          "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+          "dev": true,
+          "requires": {
+            "unique-slug": "^3.0.0"
           }
         },
         "unique-slug": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-          "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+          "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "dev": true,
-          "requires": {
-            "builtins": "^5.0.0"
-          }
-        },
-        "which": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-          "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
@@ -23612,13 +24158,13 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
-      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz",
+      "integrity": "sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==",
       "dev": true,
       "requires": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^9.0.0",
+        "minipass": "^5.0.0"
       },
       "dependencies": {
         "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-mocha": "10.1.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "6.1.1",
-    "lerna": "6.6.2",
+    "lerna": "6.6.1",
     "lerna-changelog": "2.2.0",
     "mocha": "10.2.0",
     "nyc": "^15.1.0",


### PR DESCRIPTION
Reverts serialport/node-serialport#2633

Unable to get lerna to publish on master, seeing if this is the reason. I can't easily test this as publishing actually requires to be on the latest commit.