### PR TITLE
feat: Implement Duplex destroy

### DIFF
--- a/packages/stream/lib/index.test.ts
+++ b/packages/stream/lib/index.test.ts
@@ -791,6 +791,26 @@ describe('SerialPort', () => {
         })
       })
     })
+
+    describe('#destroy', () => {
+      it('calls close', done => {
+        const port = new SerialPortStream(openOpts)
+        port.on('close', () => done())
+        port.destroy()
+      })
+
+      it("doesn't open after destroy", done => {
+        const port = new SerialPortStream(openOpts)
+        port.on('open', () => {
+          port.destroy()
+          assert.isTrue(port.destroyed)
+          port.open(err => {
+            assert.instanceOf(err, Error)
+            done()
+          })
+        })
+      })
+    })
   })
 
   describe('reading data', () => {


### PR DESCRIPTION
Previously, there was no way to close a port reliably with this API. If you open a port, trying to `.close` before it's done opening would throw an error and leave the underlying port open. If you used node's `.destroy()`, `stream.addAbortSignal()`, or `[Symbol.asyncDispose]`, the underlying port would remain in an open state.

This change implements the `Duplex.destroy` method. This is different from `.close` in that once a `SerialPortStream` is destroyed, it cannot be opened again.