### PR TITLE
Fix the `package.json` reading so the `list` and `terminal` packages can be used again

### DIFF
--- a/packages/list/lib/index.ts
+++ b/packages/list/lib/index.ts
@@ -4,7 +4,7 @@ import { autoDetect, PortInfo } from '@serialport/bindings-cpp'
 import { program, Option } from 'commander'
 import { readFileSync } from 'node:fs'
 
-const { version } = JSON.parse(readFileSync('../package.json', 'utf8'))
+const { version } = JSON.parse(readFileSync(__dirname + '/../package.json', 'utf8'))
 
 const formatOption = new Option('-f, --format <type>', 'Format the output').choices(['text', 'json', 'jsonline', 'jsonl']).default('text')
 

--- a/packages/terminal/lib/index.ts
+++ b/packages/terminal/lib/index.ts
@@ -7,7 +7,7 @@ import { OutputTranslator } from './output-translator'
 import { autoDetect, AutoDetectTypes } from '@serialport/bindings-cpp'
 import { readFileSync } from 'node:fs'
 
-const { version } = JSON.parse(readFileSync('../package.json', 'utf8'))
+const { version } = JSON.parse(readFileSync(__dirname + '/../package.json', 'utf8'))
 const binding = autoDetect()
 
 const makeNumber = (input: string) => Number(input)


### PR DESCRIPTION
Fixes #2972.

This PR fixes the reading of the `package.json` for the `@serialport/list` and `@serialport/terminal` packages. 

The issue was that is was attempting to read one level up from the current working directory, rather than from the location of the javascript file. This was causing it to not be able to find the file, or find the wrong file.

The fix is to use `__dirname` to get the full path to the javascript files location so we can construct a full path to the `package.json` file to read it.