### PR TITLE
fix: avert crashes from missing package.json

### DIFF
--- a/packages/list/lib/index.ts
+++ b/packages/list/lib/index.ts
@@ -2,9 +2,8 @@
 
 import { autoDetect, PortInfo } from '@serialport/bindings-cpp'
 import { program, Option } from 'commander'
-import { readFileSync } from 'node:fs'
 
-const { version } = JSON.parse(readFileSync('../package.json', 'utf8'))
+const { version } = module.require('@serialport/list/package.json')
 
 const formatOption = new Option('-f, --format <type>', 'Format the output').choices(['text', 'json', 'jsonline', 'jsonl']).default('text')
 

--- a/packages/terminal/lib/index.ts
+++ b/packages/terminal/lib/index.ts
@@ -5,9 +5,8 @@ import { program } from 'commander'
 import { SerialPortStream, OpenOptions } from '@serialport/stream'
 import { OutputTranslator } from './output-translator'
 import { autoDetect, AutoDetectTypes } from '@serialport/bindings-cpp'
-import { readFileSync } from 'node:fs'
 
-const { version } = JSON.parse(readFileSync('../package.json', 'utf8'))
+const { version } = module.require('@serialport/terminal/package.json')
 const binding = autoDetect()
 
 const makeNumber = (input: string) => Number(input)


### PR DESCRIPTION
Previously `npx @serialport/list` and `npx @serialport/terminal` would crash as they would search the local filesystem for package.json to find the version. Now these tools print the correct version.

Fixes #2972