### PR TITLE
fix for importing version from package.json, on globally installed in Windows 11

### DIFF
--- a/packages/list/lib/index.ts
+++ b/packages/list/lib/index.ts
@@ -2,9 +2,9 @@
 
 import { autoDetect, PortInfo } from '@serialport/bindings-cpp'
 import { program, Option } from 'commander'
-import { readFileSync } from 'node:fs'
+import pkg from '../package.json' assert { type: 'json' };
 
-const { version } = JSON.parse(readFileSync('../package.json', 'utf8'))
+const { version } = pkg;
 
 const formatOption = new Option('-f, --format <type>', 'Format the output').choices(['text', 'json', 'jsonline', 'jsonl']).default('text')
 

--- a/packages/terminal/lib/index.ts
+++ b/packages/terminal/lib/index.ts
@@ -5,9 +5,9 @@ import { program } from 'commander'
 import { SerialPortStream, OpenOptions } from '@serialport/stream'
 import { OutputTranslator } from './output-translator'
 import { autoDetect, AutoDetectTypes } from '@serialport/bindings-cpp'
-import { readFileSync } from 'node:fs'
+import pkg from '../package.json' assert { type: 'json' };
 
-const { version } = JSON.parse(readFileSync('../package.json', 'utf8'))
+const { version } = pkg;
 const binding = autoDetect()
 
 const makeNumber = (input: string) => Number(input)


### PR DESCRIPTION
When installed using `npm install -g @serialport/terminal ` aka globally on Windows 11, it is unable to find the path needed to read the version in `package.json`. `readFileSync()` when ran as a globally installed package, it is unable to find the **current working directory** as it considers current terminal directory as base. So `../package.json` is being read as `C:\Users\package.json`, which does not exist, when it is supposed to read relative to its current folder aka here `C:\Users\callum\AppData\Local\nvm\v22.17.1\node_modules\@serialport\list\package.json`.

The fix is to use a path resolution resolver that works globally, while following ES Modules. 

<img width="1112" height="506" alt="image" src="https://github.com/user-attachments/assets/fcf8b9e3-503d-40f3-afb4-6668a6e7428b" />

<img width="1109" height="486" alt="image" src="https://github.com/user-attachments/assets/8046a33b-57f9-4090-83b2-12eab78f6b05" />